### PR TITLE
Modify hysteria protocol for 1xRTT UDP

### DIFF
--- a/pkg/core/protocol.go
+++ b/pkg/core/protocol.go
@@ -27,8 +27,8 @@ type clientHello struct {
 
 const (
 	serverHelloStatusFailed  = uint8(0)
-	serverHelloStatusOK      = uint8(1)
-	serverHelloStatusTCPOnly = uint8(2)
+	serverHelloStatusTCPOnly = uint8(1)
+	serverHelloStatusOK      = uint8(2)
 )
 
 type serverHello struct {

--- a/pkg/core/protocol.go
+++ b/pkg/core/protocol.go
@@ -25,15 +25,27 @@ type clientHello struct {
 	Auth    []byte
 }
 
+const (
+	serverHelloStatusFailed  = uint8(0)
+	serverHelloStatusOK      = uint8(1)
+	serverHelloStatusTCPOnly = uint8(2)
+)
+
 type serverHello struct {
-	OK         bool
+	Status     uint8
 	Rate       transmissionRate
 	MessageLen uint16 `struc:"sizeof=Message"`
 	Message    string
 }
 
+const (
+	clientRequestTypeTCP        = uint8(0)
+	clientRequestTypeUDPLegacy  = uint8(1)
+	clientRequestTypeUDPControl = uint8(2)
+)
+
 type clientRequest struct {
-	UDP     bool
+	Type    uint8
 	HostLen uint16 `struc:"sizeof=Host"`
 	Host    string
 	Port    uint16
@@ -71,6 +83,17 @@ type udpMessageV2 struct {
 	HostLen   uint16 `struc:"sizeof=Host"`
 	Host      string
 	Port      uint16
+	DataLen   uint16 `struc:"sizeof=Data"`
+	Data      []byte
+}
+
+const (
+	udpControlRequestOperationReleaseSession = uint8(1)
+)
+
+type udpControlRequest struct {
+	SessionID uint32
+	Operation uint8
 	DataLen   uint16 `struc:"sizeof=Data"`
 	Data      []byte
 }

--- a/pkg/core/server.go
+++ b/pkg/core/server.go
@@ -159,9 +159,16 @@ func (s *Server) handleControlStream(cs quic.Connection, stream quic.Stream) ([]
 	}
 	// Auth
 	ok, msg := s.connectFunc(cs.RemoteAddr(), ch.Auth, serverSendBPS, serverRecvBPS)
+	status := serverHelloStatusFailed
+	if ok {
+		status = serverHelloStatusOK
+		if s.disableUDP {
+			status = serverHelloStatusTCPOnly
+		}
+	}
 	// Response
 	err = struc.Pack(stream, &serverHello{
-		OK: ok,
+		Status: status,
 		Rate: transmissionRate{
 			SendBPS: serverSendBPS,
 			RecvBPS: serverRecvBPS,


### PR DESCRIPTION
> **Note**
> This makes break changes on the hysteria protocol, which renders the UDP unavailable for clients who connect to any server of the older version prior to this change.
> Please consider bumping the `protocolVersion` or put off this pull request until there are enough changes for a new hysteria protocol version.

Change the way to handle UDP sessions for 1xRTT UDP requests. After this change, hysteria clients will generate & manage the `sessionID` by themselves rather than request the server for a new one (which consumes an extra RTT).

Please note the `"max_conn_client"` would no longer take effect on the number of UDP sessions after this change, as we only open one QUIC stream to notify the server about the termination of all UDP sessions.

This can be a partial fix for #348, #352, and #414, it only works on UDP, but at least made some improvement on the DNS requests.