### PR TITLE
feat: fast open

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,5 @@ hy_linux
 .vscode
 
 /build/
+
+config*.json

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -134,7 +134,7 @@ func client(config *clientConfig) {
 	up, down, _ := config.Speed()
 	for {
 		try += 1
-		c, err := core.NewClient(config.Server, auth, tlsConfig, quicConfig, pktConnFunc, up, down,
+		c, err := core.NewClient(config.Server, auth, tlsConfig, quicConfig, pktConnFunc, up, down, config.FastOpen,
 			func(err error) {
 				if config.QuitOnDisconnect {
 					logrus.WithFields(logrus.Fields{

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -223,6 +223,7 @@ type clientConfig struct {
 	ReceiveWindowConn   uint64 `json:"recv_window_conn"`
 	ReceiveWindow       uint64 `json:"recv_window"`
 	DisableMTUDiscovery bool   `json:"disable_mtu_discovery"`
+	FastOpen            bool   `json:"fast_open"`
 	Resolver            string `json:"resolver"`
 	ResolvePreference   string `json:"resolve_preference"`
 }

--- a/go.mod
+++ b/go.mod
@@ -92,3 +92,5 @@ require (
 replace github.com/lucas-clemente/quic-go => github.com/apernet/quic-go v0.31.1-0.20221119235156-55bf700f2dd4
 
 replace github.com/LiamHaworth/go-tproxy => github.com/apernet/go-tproxy v0.0.0-20221025153553-ed04a2935f88
+
+replace github.com/elazarl/goproxy => github.com/apernet/goproxy v0.0.0-20221124043924-155acfaf278f

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/antonfisher/nested-logrus-formatter v1.3.1 h1:NFJIr+pzwv5QLHTPyKz9UME
 github.com/antonfisher/nested-logrus-formatter v1.3.1/go.mod h1:6WTfyWFkBc9+zyBaKIqRrg/KwMqBbodBjgbHjDz7zjA=
 github.com/apernet/go-tproxy v0.0.0-20221025153553-ed04a2935f88 h1:YNsl7PMiU9x/0CleMHJ7GUdS8y1aRTFwTxdSmLLEijQ=
 github.com/apernet/go-tproxy v0.0.0-20221025153553-ed04a2935f88/go.mod h1:uxH+nFzlJug5OHjPYmzKwvVVb9wOToeGuLNVeerwWtc=
+github.com/apernet/goproxy v0.0.0-20221124043924-155acfaf278f h1:v3Bn97M5KWzdVajNphf3PxoHdsRF/RzBVovIsH/DEvY=
+github.com/apernet/goproxy v0.0.0-20221124043924-155acfaf278f/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
 github.com/apernet/quic-go v0.31.1-0.20221119235156-55bf700f2dd4 h1:rNk86XSaAK/nPyab0ZxI2uRWwYqse9JehOVG+ijOh0I=
 github.com/apernet/quic-go v0.31.1-0.20221119235156-55bf700f2dd4/go.mod h1:0wFbizLgYzqHqtlyxyCaJKlE7bYgE6JQ+54TLd/Dq2g=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
@@ -78,8 +80,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/elazarl/goproxy v0.0.0-20221015165544-a0805db90819 h1:RIB4cRk+lBqKK3Oy0r2gRX4ui7tuhiZq2SuTtTCi0/0=
-github.com/elazarl/goproxy v0.0.0-20221015165544-a0805db90819/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
 github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
 github.com/elazarl/goproxy/ext v0.0.0-20221015165544-a0805db90819 h1:PBc3oUutXxwCibSLQCmpunGvruDnoS6kdnaL7a0xwKY=
 github.com/elazarl/goproxy/ext v0.0.0-20221015165544-a0805db90819/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=


### PR DESCRIPTION
Adds an option `fast_open` in client config to defer the response handling to the first Read() call, which allows applications to send requests without waiting for an RTT.

Tested using [docs/socks5/check.py](https://github.com/apernet/hysteria/blob/536fa24595c8fcf805cdd4eab47bdc8e757f386f/docs/socks5/check.py):

no `fast_open`:
```
Sending HTTP request to 1.1.1.1
Response received
Time: 206.59 ms
```

with `fast_open`:
```
Sending HTTP request to 1.1.1.1
Response received
Time: 105.87 ms
```

**Note that this breaks the semantics of the SOCKS5/HTTP proxy, as what's originally returned as a "host unreachable" error will become an "empty reply from server" error (because the proxy now always accepts a connection to "bait" for a request).**

For this reason, we should make this disabled by default to avoid unanticipated behavior changes.