### PR TITLE
Fix a bug that make the install script fail to start the systemD daemon

### DIFF
--- a/install_server.sh
+++ b/install_server.sh
@@ -299,6 +299,7 @@ WantedBy=multi-user.target" > /lib/systemd/system/hysteria-server@.service
 }
 
 start_hysteria() {
+  HYSTERIA_CUSTOMIZE="$(systemctl list-units | grep 'hysteria' | awk -F ' ' '{print $1}')"
   if [[ -f '/lib/systemd/system/hysteria-server.service' ]]; then
     if systemctl start "${HYSTERIA_CUSTOMIZE:-hysteria}"; then
       echo 'info: Start the Hystaria service.'
@@ -310,7 +311,7 @@ start_hysteria() {
 }
 
 stop_hysteria() {
-  HYSTERIA_CUSTOMIZE="$(systemctl list-units | grep 'hysteria@' | awk -F ' ' '{print $1}')"
+  HYSTERIA_CUSTOMIZE="$(systemctl list-units | grep 'hysteria' | awk -F ' ' '{print $1}')"
   if [[ -z "$HYSTERIA_CUSTOMIZE" ]]; then
     local hysteria_daemon_to_stop='hysteria-server.service'
   else


### PR DESCRIPTION
Added the
```bash
  HYSTERIA_CUSTOMIZE="$(systemctl list-units | grep 'hysteria' | awk -F ' ' '{print $1}')"
```
line to the `start_hysteria` function to make it work properly

also, I removed the `@` in the grep command in the script, That worked on my machine running Debian Linux, not sure if this is required in other systems.