### PR TITLE
Rewrite install_server.sh

### DIFF
--- a/install_server.sh
+++ b/install_server.sh
@@ -581,7 +581,7 @@ tpl_hysteria_server_service_base() {
 
   cat << EOF
 [Unit]
-Description=Hysteria Server Service
+Description=Hysteria Server Service (${_config_name}.json)
 After=network.target
 
 [Service]

--- a/install_server.sh
+++ b/install_server.sh
@@ -1,457 +1,965 @@
 #!/usr/bin/env bash
-# modifed from https://github.com/v2fly/fhs-install-v2ray/blob/master/install-release.sh
-# You can set this variable whatever you want in shell session right before running this script by issuing:
-# export JSON_PATH='/usr/local/etc/hysteria'
-JSON_PATH=${JSON_PATH:-/etc/hysteria}
+#
+# install_server.sh - hysteria server install script
+# Try `install_server.sh --help` for usage.
+#
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2022 Aperture Internet Laboratory
+#
+
+set -e
+
+
+###
+# SCRIPT CONFIGURATION
+###
+
+# Basename of this script
+SCRIPT_NAME="$(basename "$0")"
+
+# Path for installing executable
+EXECUTABLE_INSTALL_PATH="/usr/local/bin/hysteria"
+
+# Paths to install systemd files
+SYSTEMD_SERVICES_DIR="/etc/systemd/system"
+SYSTEMD_SYSUSERS_DIR="/etc/sysusers.d"
+SYSTEMD_TMPFILES_DIR="/etc/tmpfiles.d"
+
+# Directory to store hysteria config file
+CONFIG_DIR="/etc/hysteria"
+
+# URLs of GitHub
+REPO_URL="https://github.com/apernet/hysteria"
+API_BASE_URL="https://api.github.com/repos/apernet/hysteria"
+
+# User for running hysteria
+HYSTERIA_USER="hysteria"
+
+# Directory for ACME certificates storage
+HYSTERIA_HOME_DIR="/var/lib/hysteria"
+
+# curl command line flags.
+# To using a proxy, please specify ALL_PROXY in the environ variable, such like:
+# export ALL_PROXY=socks5h://192.0.2.1:1080
+CURL_FLAGS=(-L -q --retry 5 --retry-delay 10 --retry-max-time 60)
+
+
+###
+# AUTO DETECTED GLOBAL VARIABLE
+###
+
+# Package manager
+PACKAGE_MANAGEMENT_INSTALL=${PACKAGE_MANAGEMENT_INSTALL:-}
+
+# Operating System of current machine, supported: linux
+OPERATING_SYSTEM=${OPERATING_SYSTEM:-}
+
+# Architecture of current machine, supported: 386, amd64, arm, arm64, mipsle, s390x
+ARCHITECTURE=${ARCHITECTURE:-}
+
+
+###
+# ARGUMENTS
+###
+
+# Supported operation: install, remove, check_update
+OPERATION=
+
+# User specified version to install
+VERSION=
+
+# Force install even if installed
+FORCE=
+
+# User specified binary to install
+LOCAL_FILE=
+
+
+###
+# COMMAND REPLACEMENT & UTILITIES
+###
+
+has_command() {
+  local _command=$1
+
+  type -P "$_command" > /dev/null 2>&1
+}
 
 curl() {
-  $(type -P curl) -L -q --retry 5 --retry-delay 10 --retry-max-time 60 "$@"
+  command curl "${CURL_FLAGS[@]}" "$@"
+}
+
+mktemp() {
+  command mktemp "$@" "hyservinst.XXXXXXXXXX"
+}
+
+tput() {
+  if has_command tput; then
+    command tput "$@"
+  fi
+}
+
+tred() {
+  tput setaf 1
+}
+
+tgreen() {
+  tput setaf 2
+}
+
+tyellow() {
+  tput setaf 3
+}
+
+tblue() {
+  tput setaf 4
+}
+
+taoi() {
+  tput setaf 6
+}
+
+tbold() {
+  tput bold
+}
+
+treset() {
+  tput sgr0
+}
+
+note() {
+  local _msg="$1"
+
+  echo -e "$SCRIPT_NAME: $(tbold)note: $_msg$(treset)"
+}
+
+warning() {
+  local _msg="$1"
+
+  echo -e "$SCRIPT_NAME: $(tyellow)warning: $_msg$(treset)"
+}
+
+error() {
+  local _msg="$1"
+
+  echo -e "$SCRIPT_NAME: $(tred)error: $_msg$(treset)"
+}
+
+systemctl() {
+  if [[ "x$FORCE_NO_SYSTEMD" == "x2" ]] || ! has_command systemctl; then
+    warning "Ignored systemd command: systemctl $@"
+    return
+  fi
+
+  command systemctl "$@"
+}
+
+systemd-sysusers() {
+  if [[ "x$FORCE_NO_SYSTEMD" == "x2" ]] || ! has_command systemd-sysusers; then
+    warning "Ignored systemd command: systemd-sysusers $@"
+    return
+  fi
+
+  command systemd-sysusers "$@"
+}
+
+systemd-tmpfiles() {
+  if [[ "x$FORCE_NO_SYSTEMD" == "x2" ]] || ! has_command systemd-tmpfiles; then
+    warning "Ignored systemd command: systemd-tmpfiles $@"
+    return
+  fi
+
+  command systemd-tmpfiles "$@"
+}
+
+show_argument_error_and_exit() {
+  local _error_msg="$1"
+
+  error "$_error_msg"
+  echo "Try \"$0 --help\" for the usage." >&2
+  exit 22
+}
+
+install_content() {
+  local _install_flags="$1"
+  local _content="$2"
+  local _destination="$3"
+
+  local _tmpfile="$(mktemp)"
+
+  echo -ne "Install $_destination ... "
+  echo "$_content" > "$_tmpfile"
+  if install "$_install_flags" "$_tmpfile" "$_destination"; then
+    echo -e "ok"
+  fi
+
+  rm -f "$_tmpfile"
+}
+
+remove_file() {
+  local _target="$1"
+
+  echo -ne "Remove $_target ... "
+  if rm "$_target"; then
+    echo -e "ok"
+  fi
+}
+
+detect_package_manager() {
+  if [[ -n "$PACKAGE_MANAGEMENT_INSTALL" ]]; then
+    return 0
+  fi
+
+  if has_command apt; then
+    PACKAGE_MANAGEMENT_INSTALL='apt -y --no-install-recommends install'
+    return 0
+  fi
+
+  if has_command dnf; then
+    PACKAGE_MANAGEMENT_INSTALL='dnf -y install'
+    return 0
+  fi
+
+  if has_command yum; then
+    PACKAGE_MANAGEMENT_INSTALL='yum -y install'
+    return 0
+  fi
+
+  if has_command zypper; then
+    PACKAGE_MANAGEMENT_INSTALL='zypper install -y --no-recommends'
+    return 0
+  fi
+
+  if has_command pacman; then
+    PACKAGE_MANAGEMENT_INSTALL='pacman -Syu --noconfirm'
+    return 0
+  fi
+
+  return 1
+}
+
+install_software() {
+  local _package_name="$1"
+
+  if ! detect_package_manager; then
+    error "Supported package manager is not detected, please install the following package manually:"
+    echo
+    echo -e "\t* $_package_name"
+    echo
+    exit 65
+  fi
+
+  echo "Installing missing dependence '$_package_name' with '$PACKAGE_MANAGEMENT_INSTALL' ... "
+  if $PACKAGE_MANAGEMENT_INSTALL "$_package_name"; then
+    echo "ok"
+  else
+    error "Cannot install '$_package_name' with detected package manager, please install it manually."
+    exit 65
+  fi
+}
+
+check_permission() {
+  if [[ "$UID" -eq '0' ]]; then
+    return
+  fi
+
+  note "The user currently executing this script is not root."
+
+  case "$FORCE_NO_ROOT" in
+    '1')
+      warning "FORCE_NO_ROOT=1 is specified, we will process without root and you may encounter the insufficient privilege error."
+      ;;
+    *)
+      if has_command sudo; then
+        note "Re-running this script with sudo, you can also specify FORCE_NO_ROOT=1 to force this script running with current user."
+        sudo "$0" "$@"
+        exit $?
+      else
+        error "Please run this script with root or specify FORCE_NO_ROOT=1 to force this script running with current user."
+        exit 13
+      fi
+      ;;
+  esac
+}
+
+check_environment_operating_system() {
+  if [[ -n "$OPERATING_SYSTEM" ]]; then
+    warning "OPERATING_SYSTEM=$OPERATING_SYSTEM is specified, opreating system detection will not be perform."
+    return
+  fi
+
+  if [[ "x$(uname)" == "xLinux" ]]; then
+    OPERATING_SYSTEM=linux
+    return
+  fi
+
+  error "This script only supports Linux."
+  note "Specify OPERATING_SYSTEM=[linux|darwin|freebsd|windows] to bypass this check and force this script running on this $(uname)."
+  exit 95
+}
+
+check_environment_architecture() {
+  if [[ -n "$ARCHITECTURE" ]]; then
+    warning "ARCHITECTURE=$ARCHITECTURE is specified, architecture detection will not be performed."
+    return
+  fi
+
+  case "$(uname -m)" in
+    'i386' | 'i686')
+      ARCHITECTURE='386'
+      ;;
+    'amd64' | 'x86_64')
+      ARCHITECTURE='amd64'
+      ;;
+    'armv5tel' | 'armv6l' | 'armv7' | 'armv7l')
+      ARCHITECTURE='arm'
+      ;;
+    'armv8' | 'aarch64')
+      ARCHITECTURE='arm64'
+      ;;
+    'mips' | 'mipsle' | 'mips64' | 'mips64le')
+      ARCHITECTURE='mipsle'
+      ;;
+    's390x')
+      ARCHITECTURE='s390x'
+      ;;
+    *)
+      error "The architecture '$(uname -a)' is not supported."
+      note "Specify ARCHITECTURE=<architecture> to bypass this check and force this script running on this $(uname -m)."
+      exit 8
+      ;;
+  esac
+}
+
+check_environment_systemd() {
+  if [[ -d "/run/systemd/system" ]] || grep -q systemd <(ls -l /sbin/init); then
+    return
+  fi
+
+  case "$FORCE_NO_SYSTEMD" in
+    '1')
+      warning "FORCE_NO_SYSTEMD=1 is specified, we will process as normal even if systemd is not detected by us."
+      ;;
+    '2')
+      warning "FORCE_NO_SYSTEMD=2 is specified, we will process but all systemd related command will not be executed."
+      ;;
+    *)
+      error "This script only supports Linux distributions with systemd."
+      note "Specify FORCE_NO_SYSTEMD=1 to disable this check and force this script running as systemd is detected."
+      note "Specify FORCE_NO_SYSTEMD=2 to disable this check along with all systemd related commands."
+      ;;
+  esac
+}
+
+check_environment_curl() {
+  if has_command curl; then
+    return
+  fi
+
+  install_software curl
+}
+
+check_environment_grep() {
+  if has_command grep; then
+    return
+  fi
+
+  install_software grep
+}
+
+check_environment() {
+  check_environment_operating_system
+  check_environment_architecture
+  check_environment_systemd
+  check_environment_curl
+  check_environment_grep
+}
+
+vercmp_segment() {
+  local _lhs="$1"
+  local _rhs="$2"
+
+  if [[ "x$_lhs" == "x$_rhs" ]]; then
+    echo 0
+    return
+  fi
+  if [[ -z "$_lhs" ]]; then
+    echo -1
+    return
+  fi
+  if [[ -z "$_rhs" ]]; then
+    echo 1
+    return
+  fi
+
+  local _lhs_num="${_lhs//[A-Za-z]*/}"
+  local _rhs_num="${_rhs//[A-Za-z]*/}"
+
+  if [[ "x$_lhs_num" == "x$_rhs_num" ]]; then
+    echo 0
+    return
+  fi
+  if [[ -z "$_lhs_num" ]]; then
+    echo -1
+    return
+  fi
+  if [[ -z "$_rhs_num" ]]; then
+    echo 1
+    return
+  fi
+  local _numcmp=$(("$_lhs_num" - "$_rhs_num"))
+  if [[ "$_numcmp" -ne 0 ]]; then
+    echo "$_numcmp"
+    return
+  fi
+
+  local _lhs_suffix="${_lhs#"$_lhs_num"}"
+  local _rhs_suffix="${_rhs#"$_rhs_num"}"
+
+  if [[ "x$_lhs_suffix" == "x$_rhs_suffix" ]]; then
+    echo 0
+    return
+  fi
+  if [[ -z "$_lhs_suffix" ]]; then
+    echo 1
+    return
+  fi
+  if [[ -z "$_rhs_suffix" ]]; then
+    echo -1
+    return
+  fi
+  if [[ "$_lhs_suffix" < "$_rhs_suffix" ]]; then
+    echo -1
+    return
+  fi
+  echo 1
+}
+
+vercmp() {
+  local _lhs=${1#v}
+  local _rhs=${2#v}
+
+  while [[ -n "$_lhs" && -n "$_rhs" ]]; do
+    local _clhs="${_lhs/.*/}"
+    local _crhs="${_rhs/.*/}"
+
+    local _segcmp="$(vercmp_segment "$_clhs" "$_crhs")"
+    if [[ "$_segcmp" -ne 0 ]]; then
+      echo "$_segcmp"
+      return
+    fi
+
+    _lhs="${_lhs#"$_clhs"}"
+    _lhs="${_lhs#.}"
+    _rhs="${_rhs#"$_crhs"}"
+    _rhs="${_rhs#.}"
+  done
+
+  if [[ "x$_lhs" == "x$_rhs" ]]; then
+    echo 0
+    return
+  fi
+
+  if [[ -z "$_lhs" ]]; then
+    echo -1
+    return
+  fi
+
+  if [[ -z "$_rhs" ]]; then
+    echo 1
+    return
+  fi
+
+  return
 }
 
 
-## Demo function for processing parameters
-judgment_parameters() {
+###
+# ARGUMENTS PARSER
+###
+
+show_usage_and_exit() {
+  echo
+  echo -e "\t$(tbold)$SCRIPT_NAME$(treset) - hysteria server install script"
+  echo
+  echo -e "Usage:"
+  echo
+  echo -e "$(tbold)Install hysteria$(treset)"
+  echo -e "\t$0 [ -f | -l <file> | --version <version> ]"
+  echo -e "Flags:"
+  echo -e "\t-f, --force\tForce re-install latest or specified version even if it has been installed."
+  echo -e "\t-l, --local <file>\tInstall specified hysteria binary instead of download it."
+  echo -e "\t--version <version>\tInstall specified version instead of the latest."
+  echo
+  echo -e "$(tbold)Remove hysteria$(treset)"
+  echo -e "\t$0 --remove"
+  echo
+  echo -e "$(tbold)Check for the update$(treset)"
+  echo -e "\t$0 -c"
+  echo -e "\t$0 --check"
+  echo
+  echo -e "$(tbold)Show this help$(treset)"
+  echo -e "\t$0 -h"
+  echo -e "\t$0 --help"
+  exit 0
+}
+
+parse_arguments() {
   while [[ "$#" -gt '0' ]]; do
     case "$1" in
       '--remove')
-        if [[ "$#" -gt '1' ]]; then
-          echo 'error: Please enter the correct parameters.'
-          exit 1
+        if [[ -n "$OPERATION" && "$OPERATION" != 'remove' ]]; then
+          show_argument_error_and_exit "Option '--remove' is conflicted with other options."
         fi
-        REMOVE='1'
+        OPERATION='remove'
         ;;
       '--version')
-        VERSION="${2:?error: Please specify the correct version.}"
-        break
+        VERSION="$2"
+        if [[ -z "$VERSION" ]]; then
+          show_argument_error_and_exit "Please specify the version for option '--version'."
+        fi
+        shift
         ;;
       '-c' | '--check')
-        CHECK='1'
-        break
+        if [[ -n "$OPERATION" && "$OPERATION" != 'check' ]]; then
+          show_argument_error_and_exit "Option '-c' or '--check' is conflicted with other option."
+        fi
+        OPERATION='check_update'
         ;;
       '-f' | '--force')
         FORCE='1'
-        break
         ;;
       '-h' | '--help')
-        HELP='1'
-        break
+        show_usage_and_exit
         ;;
       '-l' | '--local')
-        LOCAL_INSTALL='1'
-        LOCAL_FILE="${2:?error: Please specify the correct local file.}"
+        LOCAL_FILE="$2"
+        if [[ -z "$LOCAL_FILE" ]]; then
+          show_argument_error_and_exit "Please specify the local binary to install for option '-l' or '--local'."
+        fi
         break
         ;;
-      '-p' | '--proxy')
-        if [[ -z "${2:?error: Please specify the proxy server address.}" ]]; then
-          exit 1
-        fi
-        PROXY="$2"
-        shift
-        ;;
       *)
-        echo "$0: unknown option -- -"
-        exit 1
+        show_argument_error_and_exit "Unknown option '$1'"
         ;;
     esac
     shift
   done
-}
+  
+  if [[ -z "$OPERATION" ]]; then
+    OPERATION='install'
+  fi
 
-install_software() {
-  package_name="$1"
-  file_to_detect="$2"
-  type -P "$file_to_detect" > /dev/null 2>&1 && return
-  if ${PACKAGE_MANAGEMENT_INSTALL} "$package_name"; then
-    echo "info: $package_name is installed."
-  else
-    echo "error: Installation of $package_name failed, please check your network."
-    exit 1
-  fi
-}
-check_if_running_as_root() {
-  # If you want to run as another user, please modify $UID to be owned by this user
-  if [[ "$UID" -ne '0' ]]; then
-    echo "WARNING: The user currently executing this script is not root. You may encounter the insufficient privilege error."
-    read -r -p "Are you sure you want to continue? [y/n] " cont_without_been_root
-    if [[ x"${cont_without_been_root:0:1}" = x'y' ]]; then
-      echo "Continuing the installation with current user..."
-    else
-      echo "Not running with root, exiting..."
-      exit 1
-    fi
-  fi
-}
-
-identify_the_operating_system_and_architecture() {
-  if [[ "$(uname)" == 'Linux' ]]; then
-    case "$(uname -m)" in
-      'i386' | 'i686')
-        MACHINE='386'
-        ;;
-      'amd64' | 'x86_64')
-        MACHINE='amd64'
-        ;;
-      'armv5tel' | 'armv6l' | 'armv7' | 'armv7l')
-        MACHINE='arm'
-        ;;
-      'armv8' | 'aarch64')
-        MACHINE='arm64'
-        ;;
-      'mips' | 'mipsle' | 'mips64' | 'mips64le')
-        MACHINE='mipsle'
-        ;;
-      *)
-        echo "error: The architecture is not supported."
-        exit 1
-        ;;
-    esac
-    if [[ ! -f '/etc/os-release' ]]; then
-      echo "error: Don't use outdated Linux distributions."
-      exit 1
-    fi
-    # Do not combine this judgment condition with the following judgment condition.
-    ## Be aware of Linux distribution like Gentoo, which kernel supports switch between Systemd and OpenRC.
-    ### Refer: https://github.com/v2fly/fhs-install-v2ray/issues/84#issuecomment-688574989
-    if [[ -f /.dockerenv ]] || grep -q 'docker\|lxc' /proc/1/cgroup && [[ "$(type -P systemctl)" ]]; then
-      true
-    elif [[ -d /run/systemd/system ]] || grep -q systemd <(ls -l /sbin/init); then
-      true
-    else
-      echo "error: Only Linux distributions using systemd are supported."
-      exit 1
-    fi
-    if [[ "$(type -P apt)" ]]; then
-      PACKAGE_MANAGEMENT_INSTALL='apt -y --no-install-recommends install'
-      PACKAGE_MANAGEMENT_REMOVE='apt purge'
-      package_provide_tput='ncurses-bin'
-    elif [[ "$(type -P dnf)" ]]; then
-      PACKAGE_MANAGEMENT_INSTALL='dnf -y install'
-      PACKAGE_MANAGEMENT_REMOVE='dnf remove'
-      package_provide_tput='ncurses'
-    elif [[ "$(type -P yum)" ]]; then
-      PACKAGE_MANAGEMENT_INSTALL='yum -y install'
-      PACKAGE_MANAGEMENT_REMOVE='yum remove'
-      package_provide_tput='ncurses'
-    elif [[ "$(type -P zypper)" ]]; then
-      PACKAGE_MANAGEMENT_INSTALL='zypper install -y --no-recommends'
-      PACKAGE_MANAGEMENT_REMOVE='zypper remove'
-      package_provide_tput='ncurses-utils'
-    elif [[ "$(type -P pacman)" ]]; then
-      PACKAGE_MANAGEMENT_INSTALL='pacman -Syu --noconfirm'
-      PACKAGE_MANAGEMENT_REMOVE='pacman -Rsn'
-      package_provide_tput='ncurses'
-    else
-      echo "error: The script does not support the package manager in this operating system."
-      exit 1
-    fi
-  else
-    echo "error: This operating system is not supported."
-    exit 1
-  fi
-}
-
-get_version() {
-  # 0: Install or update Hysteria.
-  # 1: Installed or no new version of Hysteria.
-  # 2: Install the specified version of Hysteria.
-  if [[ -n "$VERSION" ]]; then
-    RELEASE_VERSION="v${VERSION#v}"
-    return 2
-  fi
-  # Determine the version number for Hysteria installed from a local file
-  if [[ -f '/usr/local/bin/hysteria' ]]; then
-    VERSION="$(/usr/local/bin/hysteria -v | awk 'NR==1 {print $3}')"
-    CURRENT_VERSION="v${VERSION#v}"
-    if [[ "$LOCAL_INSTALL" -eq '1' ]]; then
-      RELEASE_VERSION="$CURRENT_VERSION"
-      return
-    fi
-  fi
-  # Get Hysteria release version number
-  TMP_FILE="$(mktemp)"
-  if ! curl -x "${PROXY}" -sS -H "Accept: application/vnd.github.v3+json" -o "$TMP_FILE" 'https://api.github.com/repos/apernet/hysteria/releases/latest'; then
-    "rm" "$TMP_FILE"
-    echo 'error: Failed to get release list, please check your network.'
-    exit 1
-  fi
-  RELEASE_LATEST="$(sed 'y/,/\n/' "$TMP_FILE" | grep 'tag_name' | awk -F '"' '{print $4}')"
-  "rm" "$TMP_FILE"
-  RELEASE_VERSION="v${RELEASE_LATEST#v}"
-  # Compare Hysteria version numbers
-  if [[ "$RELEASE_VERSION" != "$CURRENT_VERSION" ]]; then
-    RELEASE_VERSIONSION_NUMBER="${RELEASE_VERSION#v}"
-    RELEASE_MAJOR_VERSION_NUMBER="${RELEASE_VERSIONSION_NUMBER%%.*}"
-    RELEASE_MINOR_VERSION_NUMBER="$(echo "$RELEASE_VERSIONSION_NUMBER" | awk -F '.' '{print $2}')"
-    RELEASE_MINIMUM_VERSION_NUMBER="${RELEASE_VERSIONSION_NUMBER##*.}"
-    # shellcheck disable=SC2001
-    CURRENT_VERSIONSION_NUMBER="$(echo "${CURRENT_VERSION#v}" | sed 's/-.*//')"
-    CURRENT_MAJOR_VERSION_NUMBER="${CURRENT_VERSIONSION_NUMBER%%.*}"
-    CURRENT_MINOR_VERSION_NUMBER="$(echo "$CURRENT_VERSIONSION_NUMBER" | awk -F '.' '{print $2}')"
-    CURRENT_MINIMUM_VERSION_NUMBER="${CURRENT_VERSIONSION_NUMBER##*.}"
-    if [[ "$RELEASE_MAJOR_VERSION_NUMBER" -gt "$CURRENT_MAJOR_VERSION_NUMBER" ]]; then
-      return 0
-    elif [[ "$RELEASE_MAJOR_VERSION_NUMBER" -eq "$CURRENT_MAJOR_VERSION_NUMBER" ]]; then
-      if [[ "$RELEASE_MINOR_VERSION_NUMBER" -gt "$CURRENT_MINOR_VERSION_NUMBER" ]]; then
-        return 0
-      elif [[ "$RELEASE_MINOR_VERSION_NUMBER" -eq "$CURRENT_MINOR_VERSION_NUMBER" ]]; then
-        if [[ "$RELEASE_MINIMUM_VERSION_NUMBER" -gt "$CURRENT_MINIMUM_VERSION_NUMBER" ]]; then
-          return 0
-        else
-          return 1
-        fi
-      else
-        return 1
+  # validate arguments
+  case "$OPERATION" in
+    'install')
+      if [[ -n "$VERSION" && -n "$LOCAL_FILE" ]]; then
+        show_argument_error_and_exit '--version and --local cannot be specified together.'
       fi
-    else
-      return 1
-    fi
-  elif [[ "$RELEASE_VERSION" == "$CURRENT_VERSION" ]]; then
-    return 1
+      ;;
+    *)
+      if [[ -n "$VERSION" ]]; then
+        show_argument_error_and_exit "--version is only avaiable when install."
+      fi
+      if [[ -n "$LOCAL_FILE" ]]; then
+        show_argument_error_and_exit "--local is only avaiable when install."
+      fi
+      ;;
+  esac
+}
+
+
+###
+# FILE TEMPLATES
+###
+
+# /etc/systemd/system/hysteria-server.service
+tpl_hysteria_server_service_base() {
+  local _config_name="$1"
+
+  cat << EOF
+[Unit]
+Description=Hysteria Server Service
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=$EXECUTABLE_INSTALL_PATH -config ${_config_name}.json server
+WorkingDirectory=$CONFIG_DIR
+User=$HYSTERIA_USER
+Group=$HYSTERIA_USER
+Environment=HYSTERIA_LOG_LEVEL=info
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_RAW
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_RAW
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target
+EOF
+}
+
+# /etc/systemd/system/hysteria-server.service
+tpl_hysteria_server_service() {
+  tpl_hysteria_server_service_base 'config'
+}
+
+# /etc/systemd/system/hysteria-server@.service
+tpl_hysteria_server_x_service() {
+  tpl_hysteria_server_service_base '%i'
+}
+
+# /etc/hysteria/config.json
+tpl_etc_hysteria_config_json() {
+  cat << EOF
+{
+  "listen": ":36712",
+  "acme": {
+    "domains": [
+      "your.domain.com"
+    ],
+    "email": "your@email.com"
+  },
+  "obfs": "8ZuA2Zpqhuk8yakXvMjDqEXBwY"
+}
+EOF
+}
+
+# /etc/sysusers.d/hysteria.conf
+tpl_sysusers_conf() {
+  cat << EOF
+u $HYSTERIA_USER - "Hysteria" $HYSTERIA_HOME_DIR
+EOF
+}
+
+# /etc/tmpfiles.d/hysteria.conf
+tpl_tmpfiles_conf() {
+  cat << EOF
+d $HYSTERIA_HOME_DIR 0750 $HYSTERIA_USER $HYSTERIA_USER
+EOF
+}
+
+
+###
+# SYSTEMD
+###
+
+get_running_services() {
+  if [[ "x$FORCE_NO_SYSTEMD" == "x2" ]]; then
+    return
   fi
+
+  systemctl list-units --state=active --plain --no-legend \
+    | grep -o "hysteria-server@*[^\s]*.service" || true
+}
+
+restart_running_services() {
+  if [[ "x$FORCE_NO_SYSTEMD" == "x2" ]]; then
+    return
+  fi
+
+  echo "Restarting running service ... "
+
+  for service in $(get_running_services); do
+    echo -ne "Restarting $service ... "
+    systemctl restart "$service"
+    echo "done"
+  done
+}
+
+stop_running_services() {
+  if [[ "x$FORCE_NO_SYSTEMD" == "x2" ]]; then
+    return
+  fi
+
+  echo "Stopping running service ... "
+
+  for service in $(get_running_services); do
+    echo -ne "Stopping $service ... "
+    systemctl stop "$service"
+    echo "done"
+  done
+}
+
+
+###
+# HYSTERIA & GITHUB API
+###
+
+is_hysteria_installed() {
+  # RETURN VALUE
+  # 0: hysteria is installed
+  # 1: hysteria is not installed
+
+  if [[ -f "$EXECUTABLE_INSTALL_PATH" || -h "$EXECUTABLE_INSTALL_PATH" ]]; then
+    return 0
+  fi
+  return 1
+}
+
+get_installed_version() {
+  if is_hysteria_installed; then
+    "$EXECUTABLE_INSTALL_PATH" -v | cut -d ' ' -f 3
+  fi
+}
+
+get_latest_version() {
+  if [[ -n "$VERSION" ]]; then
+    echo "$VERSION"
+    return
+  fi
+
+  local _tmpfile=$(mktemp)
+  if ! curl -sS -H 'Accept: application/vnd.github.v3+json' "$API_BASE_URL/releases/latest" -o "$_tmpfile"; then
+    error "Failed to get latest release, please check your network."
+    exit 11
+  fi
+
+  local _latest_version=$(grep 'tag_name' "$_tmpfile" | head -1 | grep -o '"v.*"')
+  _latest_version=${_latest_version#'"'}
+  _latest_version=${_latest_version%'"'}
+
+  if [[ -n "$_latest_version" ]]; then
+    VERSION="$_latest_version"
+    echo "$_latest_version"
+  fi
+
+  rm -f "$_tmpfile"
 }
 
 download_hysteria() {
-  DOWNLOAD_LINK="https://github.com/apernet/hysteria/releases/download/$RELEASE_VERSION/hysteria-linux-$MACHINE"
-  echo "Downloading Hysteria archive: $DOWNLOAD_LINK"
-  if ! curl -x "${PROXY}" -R -H 'Cache-Control: no-cache' -o "$BIN_FILE" "$DOWNLOAD_LINK"; then
-    echo 'error: Download failed! Please check your network or try again.'
-    return 1
+  local _version="$1"
+  local _destination="$2"
+
+  local _download_url="$REPO_URL/releases/download/$_version/hysteria-$OPERATING_SYSTEM-$ARCHITECTURE"
+  echo "Downloading hysteria archive: $_download_url ..."
+  if ! curl -R -H 'Cache-Control: no-cache' "$_download_url" -o "$_destination"; then
+    error "Download failed! Please check your network and try again."
+    return 11
   fi
-}
-
-install_file() {
-  NAME="$1"
-  if [[ "$NAME" == "hysteria-linux-$MACHINE" ]] ; then
-    install -m 755 "${TMP_DIRECTORY}/$NAME" "/usr/local/bin/hysteria"
-  fi
-}
-
-install_hysteria() {
-  # Install hysteria binary to /usr/local/bin/
-  install_file hysteria-linux-$MACHINE
-  
-  # Install hysteria configuration file to $JSON_PATH
-  # shellcheck disable=SC2153
-  if [[ -z "$JSONS_PATH" ]] && [[ ! -d "$JSON_PATH" ]]; then
-    install -d "$JSON_PATH"
-    cat << EOF >> "${JSON_PATH}/config.json"
-{
-    "listen": ":36712",
-    "acme": {
-        "domains": [
-            "your.domain.com"
-        ],
-        "email": "hacker@gmail.com"
-    },
-    "obfs": "fuck me till the daylight",
-    "up_mbps": 100,
-    "down_mbps": 100
-}
-EOF
-    CONFIG_NEW='1'
-  fi
-}
-
-install_startup_service_file() {
-  useradd -s /sbin/nologin --create-home hysteria 
-	[ $? -eq 0 ] && echo "User hysteria has been added."
-  echo "[Unit]
-Description=Hysteria, a feature-packed network utility optimized for networks of poor quality
-Documentation=https://hysteria.network/
-After=network.target
-
-[Service]
-User=hysteria
-CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_NET_RAW
-AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_NET_RAW
-NoNewPrivileges=true
-WorkingDirectory=/etc/hysteria
-Environment=HYSTERIA_LOG_LEVEL=info
-ExecStart=/usr/local/bin/hysteria -c /etc/hysteria/config.json server
-Restart=on-failure
-RestartPreventExitStatus=1
-RestartSec=5
-
-[Install]
-WantedBy=multi-user.target" > /lib/systemd/system/hysteria-server.service
-  echo "[Unit]
-Description=Hysteria, a feature-packed network utility optimized for networks of poor quality
-Documentation=https://hysteria.network/
-After=network.target
-
-[Service]
-User=hysteria
-CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_NET_RAW
-AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_NET_RAW
-NoNewPrivileges=true
-WorkingDirectory=/etc/hysteria
-Environment=HYSTERIA_LOG_LEVEL=info
-ExecStart=/usr/local/bin/hysteria -c /etc/hysteria/%i.json server
-Restart=on-failure
-RestartPreventExitStatus=1
-RestartSec=5
-
-[Install]
-WantedBy=multi-user.target" > /lib/systemd/system/hysteria-server@.service
-  echo "info: Systemd service files have been installed successfully!"
-  systemctl daemon-reload
-  SYSTEMD='1'
-}
-
-start_hysteria() {
-  if [[ -f '/lib/systemd/system/hysteria-server.service' ]]; then
-    if systemctl start "${HYSTERIA_CUSTOMIZE:-hysteria}"; then
-      echo 'info: Start the Hystaria service.'
-    else
-      echo '${red}error: Failed to start Hystaria service.'
-      exit 1
-    fi
-  fi
-}
-
-stop_hysteria() {
-  HYSTERIA_CUSTOMIZE="$(systemctl list-units | grep 'hysteria@' | awk -F ' ' '{print $1}')"
-  if [[ -z "$HYSTERIA_CUSTOMIZE" ]]; then
-    local hysteria_daemon_to_stop='hysteria-server.service'
-  else
-    local hysteria_daemon_to_stop="$HYSTERIA_CUSTOMIZE"
-  fi
-  if ! systemctl stop "$hysteria_daemon_to_stop"; then
-    echo 'error: Stopping the Hystaria service failed.'
-    exit 1
-  fi
-  echo 'info: Stop the Hystaria service.'
+  return 0
 }
 
 check_update() {
-  if [[ -f '/lib/systemd/system/hysteria-server.service' ]]; then
-    get_version
-    local get_ver_exit_code=$?
-    if [[ "$get_ver_exit_code" -eq '0' ]]; then
-      echo "info: Found the latest release of Hystaria $RELEASE_VERSION . (Current release: $CURRENT_VERSION)"
-    elif [[ "$get_ver_exit_code" -eq '1' ]]; then
-      echo "info: No new version. The current version of Hystaria is $CURRENT_VERSION ."
-    fi
-    exit 0
+  # RETURN VALUE
+  # 0: update available
+  # 1: installed version is latest
+
+  echo -ne "Checking for installed version ... "
+  local _installed_version="$(get_installed_version)"
+  if [[ -n "$_installed_version" ]]; then
+    echo "$_installed_version"
   else
-    echo 'error: Hystaria is not installed.'
-    exit 1
+    echo "not installed"
   fi
+
+  echo -ne "Checking for latest version ... "
+  local _latest_version="$(get_latest_version)"
+  if [[ -n "$_latest_version" ]]; then
+    echo "$_latest_version"
+    VERSION="$_latest_version"
+  else
+    echo "failed"
+    return 1
+  fi
+
+  local _vercmp="$(vercmp "$_installed_version" "$_latest_version")"
+  if [[ "$_vercmp" -lt 0 ]]; then
+    return 0
+  fi
+
+  return 1
 }
 
-remove_hysteria() {
-  if systemctl list-unit-files | grep -qw 'hysteria'; then
-    if [[ -n "$(pidof hysteria)" ]]; then
-      stop_hysteria
-    fi
-    if ! ("rm" -r '/usr/local/bin/hysteria' \
-      '/lib/systemd/system/hysteria-server.service' \
-      '/lib/systemd/system/hysteria-server@.service'); then
-      echo 'error: Failed to remove Hysteria.'
-      exit 1
+
+###
+# ENTRY
+###
+
+perform_install_hysteria_binary() {
+  if [[ -n "$LOCAL_FILE" ]]; then
+    note "Performing local install: $LOCAL_FILE"
+
+    echo -ne "Installing hysteria executable ... "
+    
+    if install -Dm755 "$LOCAL_FILE" "$EXECUTABLE_INSTALL_PATH"; then
+      echo "ok"
     else
-      echo 'removed: /usr/local/bin/hysteria'
-      echo 'removed: /lib/systemd/system/hysteria-server.service'
-      echo 'removed: /lib/systemd/system/hysteria-server@.service'
-      echo 'Please execute the command: systemctl disable hysteria'
-      echo 'info: Hysteria has been removed.'
-      echo 'info: If necessary, manually delete the configuration and log files.'
-      exit 0
+      exit 2
     fi
+
+    return
+  fi
+
+  local _tmpfile=$(mktemp)
+
+  if ! download_hysteria "$VERSION" "$_tmpfile"; then
+    rm -f "$_tmpfile"
+    exit 11
+  fi
+
+  echo -ne "Installing hysteria executable ... "
+
+  if install -Dm755 "$_tmpfile" "$EXECUTABLE_INSTALL_PATH"; then
+    echo "ok"
   else
-    echo 'error: Hysteria is not installed.'
-    exit 1
+    exit 13
+  fi
+
+  rm -f "$_tmpfile"
+}
+
+perform_remove_hysteria_binary() {
+  remove_file "$EXECUTABLE_INSTALL_PATH"
+}
+
+perform_install_hysteria_example_config() {
+  if [[ ! -d "$CONFIG_DIR" ]]; then
+    install_content -Dm644 "$(tpl_etc_hysteria_config_json)" "$CONFIG_DIR/config.json"
   fi
 }
 
-# Explanation of parameters in the script
-show_help() {
-  echo "usage: $0 [--remove | --version number | -c | -f | -h | -l | -p]"
-  echo '  [-p address] [--version number | -c | -f]'
-  echo '  --remove        Remove Hysteria'
-  echo '  --version       Install the specified version of Hysteria, e.g., --version v0.9.6'
-  echo '  -c, --check     Check if Hysteria can be updated'
-  echo '  -f, --force     Force installation of the latest version of Hysteria'
-  echo '  -h, --help      Show help'
-  echo '  -l, --local     Install Hysteria from a local file'
-  echo '  -p, --proxy     Download through a proxy server, e.g., -p http://127.0.0.1:8118 or -p socks5://127.0.0.1:1080'
-  exit 0
+perform_install_hysteria_systemd() {
+  install_content -Dm644 "$(tpl_hysteria_server_service)" "$SYSTEMD_SERVICES_DIR/hysteria-server.service"
+  install_content -Dm644 "$(tpl_hysteria_server_x_service)" "$SYSTEMD_SERVICES_DIR/hysteria-server@.service"
+  install_content -Dm644 "$(tpl_sysusers_conf)" "$SYSTEMD_SYSUSERS_DIR/hysteria.conf"
+  install_content -Dm644 "$(tpl_tmpfiles_conf)" "$SYSTEMD_TMPFILES_DIR/hysteria.conf"
+
+  systemctl daemon-reload
+  systemd-sysusers
+  systemd-tmpfiles --create
 }
 
+perform_remove_hysteria_systemd() {
+  remove_file "$SYSTEMD_SERVICES_DIR/hysteria-server.service"
+  remove_file "$SYSTEMD_SERVICES_DIR/hysteria-server@.service"
+  remove_file "$SYSTEMD_SYSUSERS_DIR/hysteria.conf"
+  remove_file "$SYSTEMD_TMPFILES_DIR/hysteria.conf"
+
+  systemctl daemon-reload
+}
+
+perform_install_hysteria_home_legacy() {
+  if ! id "$HYSTERIA_USER" > /dev/null 2>&1; then
+    echo -ne "Creating user $HYSTERIA_USER ... "
+    useradd -r -d "$HYSTERIA_HOME_DIR" -m "$HYSTERIA_USER"
+    echo "ok"
+  fi
+}
+
+perform_install() {
+  local _is_frash_install
+  if ! is_hysteria_installed; then
+    _is_frash_install=1
+  fi
+
+  local _is_update_required
+
+  if [[ -n "$LOCAL_FILE" ]] || [[ -n "$VERSION" ]] || check_update; then
+    _is_update_required=1
+  fi
+
+  if [[ "x$FORCE" == "x1" ]]; then
+    if [[ -z "$_is_update_required" ]]; then
+      note "Option '--force' is specified, re-install even if installed version is the latest."
+    fi
+    _is_update_required=1
+  fi
+
+  if [[ -z "$_is_update_required" ]]; then
+    echo "$(tgreen)Installed version is up-to-dated, there is nothing to do.$(treset)"
+    return
+  fi
+
+  perform_install_hysteria_binary
+  perform_install_hysteria_example_config
+
+  if [[ "x$FORCE_NO_SYSTEMD" == "x2" ]]; then
+    perform_install_hysteria_home_legacy
+  else
+    perform_install_hysteria_systemd
+  fi
+
+  if [[ -n "$_is_frash_install" ]]; then
+    echo
+    echo -e "$(tbold)Congratulation! Hysteria has been successfully installed on your server.$(treset)"
+    echo
+    echo -e "What's next?"
+    echo
+    echo -e "\t+ Check out the latest quick start guide at $(tblue)https://hysteria.network/docs/quick-start/$(treset)"
+    echo -e "\t+ Edit server config file at $(tred)$CONFIG_DIR/config.json$(treset)"
+    echo -e "\t+ Start your hysteria server with $(tred)systemctl start hysteria-server.service$(treset)"
+    echo -e "\t+ Configure hysteria start on system boot with $(tred)systemctl enable hysteria-server.service$(treset)"
+    echo
+  else
+    restart_running_services
+
+    echo
+    echo -e "$(tbold)Hysteria has been successfully update to $VERSION.$(treset)"
+    echo
+    echo -e "Check out the latest changelog $(tblue)https://github.com/apernet/hysteria/blob/master/CHANGELOG.md$(treset)"
+    echo
+  fi
+}
+
+perform_remove() {
+  perform_remove_hysteria_binary
+  stop_running_services
+  perform_remove_hysteria_systemd
+
+  echo
+  echo -e "$(tbold)Congratulation! Hysteria has been successfully removed from your server.$(treset)"
+  echo
+  echo -e "You still need to remove configuration files and ACME certificates manually with the following commands:"
+  echo
+  echo -e "\t$(tred)rm -rf "$CONFIG_DIR"$(treset)"
+  echo -e "\t$(tred)userdel -f "$HYSTERIA_USER"$(treset)"
+  if [[ "x$FORCE_NO_SYSTEMD" != "x2" ]]; then
+    echo
+    echo -e "You still might need to disable all related systemd services with the following commands:"
+    echo
+    echo -e "\t$(tred)rm -f /etc/systemd/system/multi-user.target.wants/hysteria-server.service$(treset)"
+    echo -e "\t$(tred)rm -f /etc/systemd/system/multi-user.target.wants/hysteria-server@*.service$(treset)"
+    echo -e "\t$(tred)systemctl daemon-reload$(treset)"
+  fi
+  echo
+}
+
+perform_check_update() {
+  if check_update; then
+    echo
+    echo -e "$(tbold)Update available: $VERSION$(treset)"
+    echo
+    echo -e "$(tgreen)You can download and install the latest version by execute this script without any arguments.$(treset)"
+    echo
+  else
+    echo
+    echo "$(tgreen)Installed version is up-to-dated.$(treset)"
+    echo
+  fi
+}
 
 main() {
-  check_if_running_as_root
-  identify_the_operating_system_and_architecture
-  judgment_parameters "$@"
+  parse_arguments "$@"
 
-  install_software "$package_provide_tput" 'tput'
-  red=$(tput setaf 1)
-  green=$(tput setaf 2)
-  aoi=$(tput setaf 6)
-  reset=$(tput sgr0)
+  check_permission
+  check_environment
 
-  # Parameter information
-  [[ "$HELP" -eq '1' ]] && show_help
-  [[ "$CHECK" -eq '1' ]] && check_update
-  [[ "$REMOVE" -eq '1' ]] && remove_hysteria
-
-  # Two very important variables
-  TMP_DIRECTORY="$(mktemp -d)"
-  BIN_FILE="${TMP_DIRECTORY}/hysteria-linux-$MACHINE"
-
-  # Install Hysteria from a local file, but still need to make sure the network is available
-  if [[ "$LOCAL_INSTALL" -eq '1' ]]; then
-    echo 'warn: Install Hysteria from a local file, but still need to make sure the network is available.'
-    echo -n 'warn: Please make sure the file is valid because we cannot confirm it. (Press any key) ...'
-    read -r
-  else
-    # Normal way
-    install_software 'curl' 'curl'
-    get_version
-    NUMBER="$?"
-    if [[ "$NUMBER" -eq '0' ]] || [[ "$FORCE" -eq '1' ]] || [[ "$NUMBER" -eq 2 ]]; then
-      echo "info: Installing Hysteria $RELEASE_VERSION for $(uname -m)"
-      download_hysteria
-      if [[ "$?" -eq '1' ]]; then
-        "rm" -r "$TMP_DIRECTORY"
-        echo "removed: $TMP_DIRECTORY"
-        exit 1
-      fi
-    elif [[ "$NUMBER" -eq '1' ]]; then
-      echo "info: No new version. The current version of Hysteria is $CURRENT_VERSION ."
-      exit 0
-    fi
-  fi
-
-  # Determine if Hysteria is running
-  if systemctl list-unit-files | grep -qw 'hysteria'; then
-    if [[ -n "$(pidof hysteria)" ]]; then
-      stop_hysteria
-      HYSTERIA_RUNNING='1'
-    fi
-  fi
-  install_hysteria
-  install_startup_service_file
-  echo 'installed: /usr/local/bin/hysteria'
-  # If the file exists, the content output of installing or updating geoip.dat and geosite.dat will not be displayed
-  if [[ "$CONFIG_NEW" -eq '1' ]]; then
-    echo "installed: ${JSON_PATH}/config.json"
-  fi
-  if [[ "$SYSTEMD" -eq '1' ]]; then
-    echo 'installed: /lib/systemd/system/hysteria-server.service'
-    echo 'installed: /lib/systemd/system/hysteria-server@.service'
-  fi
-  "rm" -r "$TMP_DIRECTORY"
-  echo "removed: $TMP_DIRECTORY"
-  if [[ "$LOCAL_INSTALL" -eq '1' ]]; then
-    get_version
-  fi
-  echo "info: Hysteria $RELEASE_VERSION is installed."
-  if [[ "$HYSTERIA_RUNNING" -eq '1' ]]; then
-    start_hysteria
-  else
-    echo 'Please execute the command: systemctl enable hysteria-server; systemctl start hysteria-server'
-  fi
+  case "$OPERATION" in
+    "install")
+      perform_install
+      ;;
+    "remove")
+      perform_remove
+      ;;
+    "check_update")
+      perform_check_update
+      ;;
+    *)
+      error "Unknown operation '$OPERATION'."
+      ;;
+  esac
 }
 
 main "$@"
+
+# vim:set ft=bash ts=2 sw=2 sts=2 et:

--- a/install_server.sh
+++ b/install_server.sh
@@ -41,7 +41,7 @@ HYSTERIA_HOME_DIR="/var/lib/hysteria"
 # curl command line flags.
 # To using a proxy, please specify ALL_PROXY in the environ variable, such like:
 # export ALL_PROXY=socks5h://192.0.2.1:1080
-CURL_FLAGS=(-L -q --retry 5 --retry-delay 10 --retry-max-time 60)
+CURL_FLAGS=(-L -f -q --retry 5 --retry-delay 10 --retry-max-time 60)
 
 
 ###

--- a/install_server.sh
+++ b/install_server.sh
@@ -146,6 +146,21 @@ error() {
   echo -e "$SCRIPT_NAME: $(tred)error: $_msg$(treset)"
 }
 
+has_prefix() {
+    local _s="$1"
+    local _prefix="$2"
+
+    if [[ -z "$_prefix" ]]; then
+        return 0
+    fi
+
+    if [[ -z "$_s" ]]; then
+        return 1
+    fi
+
+    [[ "x$_s" != "x${_s#"$_prefix"}" ]]
+}
+
 systemctl() {
   if [[ "x$FORCE_NO_SYSTEMD" == "x2" ]] || ! has_command systemctl; then
     warning "Ignored systemd command: systemctl $@"
@@ -501,6 +516,9 @@ parse_arguments() {
           show_argument_error_and_exit "Please specify the version for option '--version'."
         fi
         shift
+        if ! has_prefix "$VERSION" 'v'; then
+          show_argument_error_and_exit "Version numbers should begin with 'v' (such like 'v1.3.1'), got '$VERSION'"
+        fi
         ;;
       '-c' | '--check')
         if [[ -n "$OPERATION" && "$OPERATION" != 'check' ]]; then

--- a/install_server.sh
+++ b/install_server.sh
@@ -719,7 +719,6 @@ get_latest_version() {
   _latest_version=${_latest_version%'"'}
 
   if [[ -n "$_latest_version" ]]; then
-    VERSION="$_latest_version"
     echo "$_latest_version"
   fi
 

--- a/install_server.sh
+++ b/install_server.sh
@@ -911,7 +911,7 @@ perform_remove() {
   echo -e "You still need to remove configuration files and ACME certificates manually with the following commands:"
   echo
   echo -e "\t$(tred)rm -rf "$CONFIG_DIR"$(treset)"
-  echo -e "\t$(tred)userdel -f "$HYSTERIA_USER"$(treset)"
+  echo -e "\t$(tred)userdel -rf "$HYSTERIA_USER"$(treset)"
   if [[ "x$FORCE_NO_SYSTEMD" != "x2" ]]; then
     echo
     echo -e "You still might need to disable all related systemd services with the following commands:"

--- a/install_server.sh
+++ b/install_server.sh
@@ -17,6 +17,9 @@ set -e
 # Basename of this script
 SCRIPT_NAME="$(basename "$0")"
 
+# Command line arguments of this script
+SCRIPT_ARGS=("$@")
+
 # Path for installing executable
 EXECUTABLE_INSTALL_PATH="/usr/local/bin/hysteria"
 
@@ -272,8 +275,7 @@ check_permission() {
     *)
       if has_command sudo; then
         note "Re-running this script with sudo, you can also specify FORCE_NO_ROOT=1 to force this script running with current user."
-        sudo "$0" "$@"
-        exit $?
+        exec sudo "$0" "${SCRIPT_ARGS[@]}"
       else
         error "Please run this script with root or specify FORCE_NO_ROOT=1 to force this script running with current user."
         exit 13


### PR DESCRIPTION
I noted there are still some users of this script. So I rewrite it to solve some historical issues and make it more user-friendly.

## Features
+ Better user interface with more colorful hints (see screenshots).
+ Correctly detecting and restarting multiple running hysteria-server systemd services after hysteria upgraded, this also fixes #513 and #514 
+ Auto re-exec with sudo when run as non-root user (supports VPS uses non-root login user, such as GCP). 
+ Better command line flags parser.

## Screenshots
![image](https://user-images.githubusercontent.com/13131972/204194389-8164abdf-6dd5-4bb1-8f11-bdd5fe3a0568.png)
![image](https://user-images.githubusercontent.com/13131972/204194412-4b61e257-982b-47c8-b6d1-3d71216100d9.png)
![image](https://user-images.githubusercontent.com/13131972/204196649-e173fb37-53cd-4d11-ab20-397c4c9b7493.png)
