### PR TITLE
chore(go-task): supported amd64-v* & s390x

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,4 +1,21 @@
+##############################################################################
+#                                                                            #
+#    go-task: https://taskfile.dev/installation/                             #
+#                                                                            #
+#    For the role of 'amd64-v*', please refer to                             #
+#        https://en.wikipedia.org/wiki/X86-64#Microarchitecture_levels.      #
+#                                                                            #
+##############################################################################
+
 version: '3'
+
+vars:
+  BUILD_VERSION:
+    sh: git describe --tags --always --match 'v*'
+  BUILD_COMMIT:
+    sh: git rev-parse HEAD
+  BUILD_DATE:
+    sh: date -u '+%F %T'
 
 tasks:
   clean:
@@ -11,18 +28,11 @@ tasks:
       - sha256sum hysteria-* > hashes.txt
   build-hysteria:
     label: build-{{.TASK}}
-    vars:
-      BUILD_VERSION:
-        sh: git describe --tags --always --match 'v*'
-      BUILD_COMMIT:
-        sh: git rev-parse HEAD
-      BUILD_DATE:
-        sh: date -u '+%F %T'
-    dir: ./app/cmd/
+    dir: ./app/cmd
     cmds:
       - |
         GOOS={{.GOOS}} GOARCH={{.GOARCH}} GOARM={{.GOARM}} GOAMD64={{.GOAMD64}} GOMIPS={{.GOMIPS}} \
-        go build -trimpath -o ../../dist/hysteria-{{.TASK}} -ldflags \
+        go build -trimpath -o ../../dist/hysteria-{{.TASK}}{{.BINEXT}} -ldflags \
         "-w -s -X 'main.appVersion={{.BUILD_VERSION}}' -X 'main.appCommit={{.BUILD_COMMIT}}' -X 'main.appDate={{.BUILD_DATE}}'"
   linux-386:
     cmds:
@@ -39,6 +49,24 @@ tasks:
           TASK: "{{.TASK}}",
           GOOS: linux,
           GOARCH: amd64
+        }
+  linux-amd64-v2:
+    cmds:
+      - task: build-hysteria
+        vars: {
+          TASK: "{{.TASK}}",
+          GOOS: linux,
+          GOARCH: amd64,
+          GOAMD64: v2
+        }
+  linux-amd64-v3:
+    cmds:
+      - task: build-hysteria
+        vars: {
+          TASK: "{{.TASK}}",
+          GOOS: linux,
+          GOARCH: amd64,
+          GOAMD64: v3
         }
   linux-amd64-v4:
     cmds:
@@ -83,6 +111,14 @@ tasks:
           TASK: "{{.TASK}}",
           GOOS: linux,
           GOARCH: arm64
+        }
+  linux-s390x:
+    cmds:
+      - task: build-hysteria
+        vars: {
+          TASK: "{{.TASK}}",
+          GOOS: linux,
+          GOARCH: s390x
         }
   linux-mips-hardfloat:
     cmds:
@@ -135,6 +171,24 @@ tasks:
           GOOS: darwin,
           GOARCH: amd64
         }
+  darwin-amd64-v2:
+    cmds:
+      - task: build-hysteria
+        vars: {
+          TASK: "{{.TASK}}",
+          GOOS: darwin,
+          GOARCH: amd64,
+          GOAMD64: v2
+        }
+  darwin-amd64-v3:
+    cmds:
+      - task: build-hysteria
+        vars: {
+          TASK: "{{.TASK}}",
+          GOOS: darwin,
+          GOARCH: amd64,
+          GOAMD64: v3
+        }
   darwin-amd64-v4:
     cmds:
       - task: build-hysteria
@@ -168,6 +222,24 @@ tasks:
           GOOS: freebsd,
           GOARCH: amd64
         }
+  freebsd-amd64-v2:
+    cmds:
+      - task: build-hysteria
+        vars: {
+          TASK: "{{.TASK}}",
+          GOOS: freebsd,
+          GOARCH: amd64,
+          GOAMD64: v2
+        }
+  freebsd-amd64-v3:
+    cmds:
+      - task: build-hysteria
+        vars: {
+          TASK: "{{.TASK}}",
+          GOOS: freebsd,
+          GOARCH: amd64,
+          GOAMD64: v3
+        }
   freebsd-amd64-v4:
     cmds:
       - task: build-hysteria
@@ -197,7 +269,8 @@ tasks:
     cmds:
       - task: build-hysteria
         vars: {
-          TASK: "{{.TASK}}.exe",
+          TASK: "{{.TASK}}",
+          BINEXT: ".exe",
           GOOS: windows,
           GOARCH: 386
         }
@@ -205,15 +278,37 @@ tasks:
     cmds:
       - task: build-hysteria
         vars: {
-          TASK: "{{.TASK}}.exe",
+          TASK: "{{.TASK}}",
+          BINEXT: ".exe",
           GOOS: windows,
           GOARCH: amd64
+        }
+  windows-amd64-v2:
+    cmds:
+      - task: build-hysteria
+        vars: {
+          TASK: "{{.TASK}}",
+          BINEXT: ".exe",
+          GOOS: windows,
+          GOARCH: amd64,
+          GOAMD64: v2
+        }
+  windows-amd64-v3:
+    cmds:
+      - task: build-hysteria
+        vars: {
+          TASK: "{{.TASK}}",
+          BINEXT: ".exe",
+          GOOS: windows,
+          GOARCH: amd64,
+          GOAMD64: v3
         }
   windows-amd64-v4:
     cmds:
       - task: build-hysteria
         vars: {
-          TASK: "{{.TASK}}.exe",
+          TASK: "{{.TASK}}",
+          BINEXT: ".exe",
           GOOS: windows,
           GOARCH: amd64,
           GOAMD64: v4
@@ -222,7 +317,8 @@ tasks:
     cmds:
       - task: build-hysteria
         vars: {
-          TASK: "{{.TASK}}.exe",
+          TASK: "{{.TASK}}",
+          BINEXT: ".exe",
           GOOS: windows,
           GOARCH: arm64
         }
@@ -231,26 +327,35 @@ tasks:
       - task: clean
       - task: linux-386
       - task: linux-amd64
+      - task: linux-amd64-v2
+      - task: linux-amd64-v3
       - task: linux-amd64-v4
       - task: linux-armv5
       - task: linux-armv6
       - task: linux-armv7
       - task: linux-armv8
+      - task: linux-s390x
       - task: linux-mips-hardfloat
       - task: linux-mipsle-softfloat
       - task: linux-mipsle-hardfloat
       - task: linux-mips64
       - task: linux-mips64le
       - task: darwin-amd64
+      - task: darwin-amd64-v2
+      - task: darwin-amd64-v3
       - task: darwin-amd64-v4
       - task: darwin-arm64
       - task: freebsd-386
       - task: freebsd-amd64
+      - task: freebsd-amd64-v2
+      - task: freebsd-amd64-v3
       - task: freebsd-amd64-v4
       - task: freebsd-arm
       - task: freebsd-arm64
       - task: windows-386
       - task: windows-amd64
+      - task: windows-amd64-v2
+      - task: windows-amd64-v3
       - task: windows-amd64-v4
       - task: windows-arm64
       - task: hash


### PR DESCRIPTION
supported amd64-v* & s390x

Signed-off-by: kovacs <mritd@linux.com>