### PR TITLE
Add `lazy_start` option.

### DIFF
--- a/app/cmd/client.go
+++ b/app/cmd/client.go
@@ -172,8 +172,7 @@ func client(config *clientConfig) {
 	}
 	defer client.Close()
 	if config.LazyStart {
-		logrus.WithField("addr", config.Server).Info("Option lazy_start specified. Server connection deferred.")
-
+		logrus.WithField("addr", config.Server).Info("Lazy start enabled, waiting for first connection")
 	} else {
 		logrus.WithField("addr", config.Server).Info("Connected")
 	}

--- a/app/cmd/client.go
+++ b/app/cmd/client.go
@@ -136,6 +136,7 @@ func client(config *clientConfig) {
 	for {
 		try += 1
 		c, err := cs.NewClient(config.Server, auth, tlsConfig, quicConfig, pktConnFunc, up, down, config.FastOpen,
+			config.LazyStart,
 			func(err error) {
 				if config.QuitOnDisconnect {
 					logrus.WithFields(logrus.Fields{
@@ -170,7 +171,12 @@ func client(config *clientConfig) {
 		}
 	}
 	defer client.Close()
-	logrus.WithField("addr", config.Server).Info("Connected")
+	if config.LazyStart {
+		logrus.WithField("addr", config.Server).Info("Option lazy_start specified. Server connection deferred.")
+
+	} else {
+		logrus.WithField("addr", config.Server).Info("Connected")
+	}
 
 	// Local
 	errChan := make(chan error)

--- a/app/cmd/config.go
+++ b/app/cmd/config.go
@@ -227,6 +227,7 @@ type clientConfig struct {
 	ReceiveWindow       uint64 `json:"recv_window"`
 	DisableMTUDiscovery bool   `json:"disable_mtu_discovery"`
 	FastOpen            bool   `json:"fast_open"`
+	LazyStart           bool   `json:"lazy_start"`
 	Resolver            string `json:"resolver"`
 	ResolvePreference   string `json:"resolve_preference"`
 }


### PR DESCRIPTION
When on, the client will not attempt to connect to the server at startup, only when a connection is initiated.

This behavior matches that of trojan, v2ray and tuic, but behind a config option for compatibility.