### PR TITLE
fix: Fix slice out-of-bounds issues in ParseUDPMessage.

### DIFF
--- a/core/internal/protocol/proxy.go
+++ b/core/internal/protocol/proxy.go
@@ -212,6 +212,9 @@ func ParseUDPMessage(msg []byte) (*UDPMessage, error) {
 		return nil, errors.ProtocolError{Message: "invalid address length"}
 	}
 	bs := buf.Bytes()
+	if len(bs) < int(lAddr) {
+		return nil, errors.ProtocolError{Message: "message length mismatch"}
+	}
 	m.Addr = string(bs[:lAddr])
 	m.Data = bs[lAddr:]
 	return m, nil

--- a/core/internal/protocol/proxy.go
+++ b/core/internal/protocol/proxy.go
@@ -212,8 +212,9 @@ func ParseUDPMessage(msg []byte) (*UDPMessage, error) {
 		return nil, errors.ProtocolError{Message: "invalid address length"}
 	}
 	bs := buf.Bytes()
-	if len(bs) < int(lAddr) {
-		return nil, errors.ProtocolError{Message: "message length mismatch"}
+	if len(bs) <= int(lAddr) {
+		// We use <= instead of < here as we expect at least one byte of data after the address
+		return nil, errors.ProtocolError{Message: "invalid message length"}
 	}
 	m.Addr = string(bs[:lAddr])
 	m.Data = bs[lAddr:]


### PR DESCRIPTION
My public hysteria2 node panicked yesterday, so I checked my log file and added slice length checking in this function.
```
Oct 19 15:56:44 ziyong hysteria[1110255]: 2023-10-19T15:56:44+08:00        ERROR        UDP error        {"addr": "x.x.x.x:58411", "id": "xxxx", "sessionID": 16912948, "error": "strconv.Atoi: parsing \"20715\\xf2\\x0f\\xf8\\x8c\\xb1$\\xe5It6\\xd9+\\\";\\x84\\x8b\\xe7 h\\xa5\\xd5Qu\\xffFpL\\xc1xNX\\x90U<\": invalid syntax"}
Oct 19 15:56:45 ziyong hysteria[1110255]: panic: runtime error: slice bounds out of range [:46] with capacity 41
Oct 19 15:56:45 ziyong hysteria[1110255]: goroutine 249844 [running]:
Oct 19 15:56:45 ziyong hysteria[1110255]: github.com/apernet/hysteria/core/internal/protocol.ParseUDPMessage({0xc0009808c0, 0x32, 0x32})
Oct 19 15:56:45 ziyong hysteria[1110255]:         github.com/apernet/hysteria/core/internal/protocol/proxy.go:215 +0x306
Oct 19 15:56:45 ziyong hysteria[1110255]: github.com/apernet/hysteria/core/server.(*udpIOImpl).ReceiveMessage(0xc000035780)
Oct 19 15:56:45 ziyong hysteria[1110255]:         github.com/apernet/hysteria/core/server/server.go:266 +0x4a
Oct 19 15:56:45 ziyong hysteria[1110255]: github.com/apernet/hysteria/core/server.(*udpSessionManager).Run(0xc0008529b0)
Oct 19 15:56:45 ziyong hysteria[1110255]:         github.com/apernet/hysteria/core/server/udp.go:136 +0x102
Oct 19 15:56:45 ziyong hysteria[1110255]: created by github.com/apernet/hysteria/core/server.(*h3sHandler).ServeHTTP.func1 in goroutine 249843
Oct 19 15:56:45 ziyong hysteria[1110255]:         github.com/apernet/hysteria/core/server/server.go:170 +0x26b
Oct 19 15:56:45 ziyong systemd[1]: hysteria-server.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
```