### PR TITLE
Add hysteria listening address logging output when starting up

### DIFF
--- a/app/cmd/server.go
+++ b/app/cmd/server.go
@@ -729,8 +729,11 @@ func runServer(cmd *cobra.Command, args []string) {
 	if err != nil {
 		logger.Fatal("failed to initialize server", zap.Error(err))
 	}
-	logger.Info("hysteria server up and running", zap.String("listen", config.Listen))
-
+	if config.Listen == "" {
+		logger.Info("hysteria server up and running on default address", zap.String("listen", ":443"))
+	} else {
+		logger.Info("hysteria server up and running", zap.String("listen", config.Listen))
+	}
 	if !disableUpdateCheck {
 		go runCheckUpdateServer()
 	}


### PR DESCRIPTION
![image](https://github.com/apernet/hysteria/assets/20227709/1eb75b06-b134-4e5c-b0ab-079e6b55526a)
Add hysteria listening address logging output when starting up. It would be useful to tell someone when he forgets to write 'listen' option, but the server is still running on default port 443