### PR TITLE
Add hysteria listening address logging output when starting up

### DIFF
--- a/app/cmd/server.go
+++ b/app/cmd/server.go
@@ -29,6 +29,10 @@ import (
 	"github.com/apernet/hysteria/extras/trafficlogger"
 )
 
+const (
+	defaultListenAddr = ":443"
+)
+
 var serverCmd = &cobra.Command{
 	Use:   "server",
 	Short: "Server mode",
@@ -208,7 +212,7 @@ type serverConfigMasquerade struct {
 func (c *serverConfig) fillConn(hyConfig *server.Config) error {
 	listenAddr := c.Listen
 	if listenAddr == "" {
-		listenAddr = ":443"
+		listenAddr = defaultListenAddr
 	}
 	uAddr, err := net.ResolveUDPAddr("udp", listenAddr)
 	if err != nil {
@@ -729,11 +733,12 @@ func runServer(cmd *cobra.Command, args []string) {
 	if err != nil {
 		logger.Fatal("failed to initialize server", zap.Error(err))
 	}
-	if config.Listen == "" {
-		logger.Info("hysteria server up and running on default address", zap.String("listen", ":443"))
+	if config.Listen != "" {
+		logger.Info("server up and running", zap.String("listen", config.Listen))
 	} else {
-		logger.Info("hysteria server up and running", zap.String("listen", config.Listen))
+		logger.Info("server up and running", zap.String("listen", defaultListenAddr))
 	}
+
 	if !disableUpdateCheck {
 		go runCheckUpdateServer()
 	}

--- a/app/cmd/server.go
+++ b/app/cmd/server.go
@@ -729,7 +729,7 @@ func runServer(cmd *cobra.Command, args []string) {
 	if err != nil {
 		logger.Fatal("failed to initialize server", zap.Error(err))
 	}
-	logger.Info("server up and running")
+	logger.Info("hysteria server up and running", zap.String("listen", config.Listen))
 
 	if !disableUpdateCheck {
 		go runCheckUpdateServer()

--- a/app/cmd/server.go
+++ b/app/cmd/server.go
@@ -729,8 +729,11 @@ func runServer(cmd *cobra.Command, args []string) {
 	if err != nil {
 		logger.Fatal("failed to initialize server", zap.Error(err))
 	}
-	logger.Info("hysteria server up and running", zap.String("listen", config.Listen))
-
+	if config.Listen == "" {
+		logger.Info("hysteria server up and running on default address", zap.String("listen", ":443"))
+	} else {
+		logger.Info("hysteria server up and running", zap.String("listen", config.Listen))
+	}
 	if !disableUpdateCheck {
 		go runCheckUpdateServer()
 	}


### PR DESCRIPTION
![image](https://github.com/apernet/hysteria/assets/20227709/1eb75b06-b134-4e5c-b0ab-079e6b55526a)
Add hysteria listening address logging output when starting up. It would be useful to tell someone when he forgets to write 'listen' option, but the server is still running on default port 443