### PR TITLE
fix: ipv{4,6}-only listen on wildcard address

### DIFF
--- a/app/cmd/client.go
+++ b/app/cmd/client.go
@@ -11,8 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/apernet/hysteria/extras/correctnet"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
@@ -25,6 +23,7 @@ import (
 	"github.com/apernet/hysteria/app/internal/url"
 	"github.com/apernet/hysteria/app/internal/utils"
 	"github.com/apernet/hysteria/core/client"
+	"github.com/apernet/hysteria/extras/correctnet"
 	"github.com/apernet/hysteria/extras/obfs"
 	"github.com/apernet/hysteria/extras/transport/udphop"
 )

--- a/app/cmd/client.go
+++ b/app/cmd/client.go
@@ -5,12 +5,13 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"errors"
-	"github.com/apernet/hysteria/extras/correctnet"
 	"net"
 	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/apernet/hysteria/extras/correctnet"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/app/cmd/client.go
+++ b/app/cmd/client.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"errors"
+	"github.com/apernet/hysteria/extras/correctnet"
 	"net"
 	"os"
 	"strconv"
@@ -504,7 +505,7 @@ func clientSOCKS5(config socks5Config, c client.Client) error {
 	if config.Listen == "" {
 		return configError{Field: "listen", Err: errors.New("listen address is empty")}
 	}
-	l, err := net.Listen("tcp", config.Listen)
+	l, err := correctnet.Listen("tcp", config.Listen)
 	if err != nil {
 		return configError{Field: "listen", Err: err}
 	}
@@ -529,7 +530,7 @@ func clientHTTP(config httpConfig, c client.Client) error {
 	if config.Listen == "" {
 		return configError{Field: "listen", Err: errors.New("listen address is empty")}
 	}
-	l, err := net.Listen("tcp", config.Listen)
+	l, err := correctnet.Listen("tcp", config.Listen)
 	if err != nil {
 		return configError{Field: "listen", Err: err}
 	}
@@ -562,7 +563,7 @@ func clientTCPForwarding(entries []tcpForwardingEntry, c client.Client) error {
 		if e.Remote == "" {
 			return configError{Field: "remote", Err: errors.New("remote address is empty")}
 		}
-		l, err := net.Listen("tcp", e.Listen)
+		l, err := correctnet.Listen("tcp", e.Listen)
 		if err != nil {
 			return configError{Field: "listen", Err: err}
 		}
@@ -589,7 +590,7 @@ func clientUDPForwarding(entries []udpForwardingEntry, c client.Client) error {
 		if e.Remote == "" {
 			return configError{Field: "remote", Err: errors.New("remote address is empty")}
 		}
-		l, err := net.ListenPacket("udp", e.Listen)
+		l, err := correctnet.ListenPacket("udp", e.Listen)
 		if err != nil {
 			return configError{Field: "listen", Err: err}
 		}

--- a/app/cmd/server.go
+++ b/app/cmd/server.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/apernet/hysteria/extras/correctnet"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -219,7 +220,7 @@ func (c *serverConfig) fillConn(hyConfig *server.Config) error {
 	if err != nil {
 		return configError{Field: "listen", Err: err}
 	}
-	conn, err := net.ListenUDP("udp", uAddr)
+	conn, err := correctnet.ListenUDP("udp", uAddr)
 	if err != nil {
 		return configError{Field: "listen", Err: err}
 	}
@@ -752,7 +753,7 @@ func runServer(cmd *cobra.Command, args []string) {
 
 func runTrafficStatsServer(listen string, handler http.Handler) {
 	logger.Info("traffic stats server up and running", zap.String("listen", listen))
-	if err := http.ListenAndServe(listen, handler); err != nil {
+	if err := correctnet.HTTPListenAndServe(listen, handler); err != nil {
 		logger.Fatal("failed to serve traffic stats", zap.Error(err))
 	}
 }

--- a/app/cmd/server.go
+++ b/app/cmd/server.go
@@ -14,8 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/apernet/hysteria/extras/correctnet"
-
 	"github.com/caddyserver/certmagic"
 	"github.com/mholt/acmez/acme"
 	"github.com/spf13/cobra"
@@ -25,6 +23,7 @@ import (
 	"github.com/apernet/hysteria/app/internal/utils"
 	"github.com/apernet/hysteria/core/server"
 	"github.com/apernet/hysteria/extras/auth"
+	"github.com/apernet/hysteria/extras/correctnet"
 	"github.com/apernet/hysteria/extras/masq"
 	"github.com/apernet/hysteria/extras/obfs"
 	"github.com/apernet/hysteria/extras/outbounds"

--- a/app/cmd/server.go
+++ b/app/cmd/server.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/apernet/hysteria/extras/correctnet"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -14,6 +13,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/apernet/hysteria/extras/correctnet"
 
 	"github.com/caddyserver/certmagic"
 	"github.com/mholt/acmez/acme"

--- a/extras/correctnet/correctnet.go
+++ b/extras/correctnet/correctnet.go
@@ -38,7 +38,7 @@ func ipAddrNetwork(addr *net.IPAddr) (network string) {
 	return "ip" + extractIPFamily(addr.IP)
 }
 
-func Listen(network string, address string) (net.Listener, error) {
+func Listen(network, address string) (net.Listener, error) {
 	if network == "tcp" {
 		tcpAddr, err := net.ResolveTCPAddr(network, address)
 		if err != nil {
@@ -56,7 +56,7 @@ func ListenTCP(network string, laddr *net.TCPAddr) (*net.TCPListener, error) {
 	return net.ListenTCP(network, laddr)
 }
 
-func ListenPacket(network string, address string) (listener net.PacketConn, err error) {
+func ListenPacket(network, address string) (listener net.PacketConn, err error) {
 	if network == "udp" {
 		udpAddr, err := net.ResolveUDPAddr(network, address)
 		if err != nil {
@@ -82,7 +82,7 @@ func ListenUDP(network string, laddr *net.UDPAddr) (*net.UDPConn, error) {
 	return net.ListenUDP(network, laddr)
 }
 
-func HTTPListenAndServe(address string, handler http.Handler) (err error) {
+func HTTPListenAndServe(address string, handler http.Handler) error {
 	listener, err := Listen("tcp", address)
 	if err != nil {
 		return err

--- a/extras/correctnet/correctnet.go
+++ b/extras/correctnet/correctnet.go
@@ -1,0 +1,92 @@
+package correctnet
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+func extractIPFamily(ip net.IP) (family string) {
+	if len(ip) == 0 {
+		// real family independent wildcard address, such as ":443"
+		return ""
+	}
+	if p4 := ip.To4(); len(p4) == net.IPv4len {
+		return "4"
+	}
+	return "6"
+}
+
+func tcpAddrNetwork(addr *net.TCPAddr) (network string) {
+	if addr == nil {
+		return "tcp"
+	}
+	return "tcp" + extractIPFamily(addr.IP)
+}
+
+func udpAddrNetwork(addr *net.UDPAddr) (network string) {
+	if addr == nil {
+		return "udp"
+	}
+	return "udp" + extractIPFamily(addr.IP)
+}
+
+func ipAddrNetwork(addr *net.IPAddr) (network string) {
+	if addr == nil {
+		return "ip"
+	}
+	return "ip" + extractIPFamily(addr.IP)
+}
+
+func Listen(network string, address string) (net.Listener, error) {
+	if network == "tcp" {
+		tcpAddr, err := net.ResolveTCPAddr(network, address)
+		if err != nil {
+			return nil, err
+		}
+		return ListenTCP(network, tcpAddr)
+	}
+	return net.Listen(network, address)
+}
+
+func ListenTCP(network string, laddr *net.TCPAddr) (*net.TCPListener, error) {
+	if network == "tcp" {
+		return net.ListenTCP(tcpAddrNetwork(laddr), laddr)
+	}
+	return net.ListenTCP(network, laddr)
+}
+
+func ListenPacket(network string, address string) (listener net.PacketConn, err error) {
+	if network == "udp" {
+		udpAddr, err := net.ResolveUDPAddr(network, address)
+		if err != nil {
+			return nil, err
+		}
+		return ListenUDP(network, udpAddr)
+	}
+	if strings.HasPrefix(network, "ip:") {
+		proto := network[3:]
+		ipAddr, err := net.ResolveIPAddr(proto, address)
+		if err != nil {
+			return nil, err
+		}
+		return net.ListenIP(ipAddrNetwork(ipAddr)+":"+proto, ipAddr)
+	}
+	return net.ListenPacket(network, address)
+}
+
+func ListenUDP(network string, laddr *net.UDPAddr) (*net.UDPConn, error) {
+	if network == "udp" {
+		return net.ListenUDP(udpAddrNetwork(laddr), laddr)
+	}
+	return net.ListenUDP(network, laddr)
+}
+
+func HTTPListenAndServe(address string, handler http.Handler) (err error) {
+	listener, err := Listen("tcp", address)
+	if err != nil {
+		return err
+	}
+	defer listener.Close()
+	return http.Serve(listener, handler)
+}

--- a/extras/masq/server.go
+++ b/extras/masq/server.go
@@ -4,9 +4,10 @@ import (
 	"bufio"
 	"crypto/tls"
 	"fmt"
-	"github.com/apernet/hysteria/extras/correctnet"
 	"net"
 	"net/http"
+
+	"github.com/apernet/hysteria/extras/correctnet"
 )
 
 // MasqTCPServer covers the TCP parts of a standard web server (TCP based HTTP/HTTPS).


### PR DESCRIPTION
Fix: #797

When listening on a wildcard address like `"0.0.0.0"` or `"[::]"`, hysteria actually listened on both IPv4 and IPv6. This is a well-known bug of the golang net package.

This PR introduces a fix for that, the intended behavior will be:

| Config        | Behavior                     |
|---------------|------------------------------|
| `0.0.0.0:443` | Listen on IPv4 only          |
| `[::]:443`    | Listen on IPv6 only          |
| `:443`        | Listen on both IPv4 and IPv6 |

Intentionly, I did not adopt this bug fix for `tcpTProxy`, `udpTProxy` and `tcpRedirect`, as they should always be dual stack listening.