### PR TITLE
fix: fail to load GeoIP or GeoSite if previous download was interrupted by network error

### DIFF
--- a/app/internal/utils/geoloader.go
+++ b/app/internal/utils/geoloader.go
@@ -119,7 +119,10 @@ func (l *GeoLoader) LoadGeoIP() (map[string]*v2geo.GeoIP, error) {
 			return err
 		})
 		if err != nil {
-			return nil, err
+			// as long as the previous download exists, fallback to it
+			if _, serr := os.Stat(filename); os.IsNotExist(serr) {
+				return nil, err
+			}
 		}
 	}
 	m, err := v2geo.LoadGeoIP(filename)
@@ -154,7 +157,10 @@ func (l *GeoLoader) LoadGeoSite() (map[string]*v2geo.GeoSite, error) {
 			return err
 		})
 		if err != nil {
-			return nil, err
+			// as long as the previous download exists, fallback to it
+			if _, serr := os.Stat(filename); os.IsNotExist(serr) {
+				return nil, err
+			}
 		}
 	}
 	m, err := v2geo.LoadGeoSite(filename)


### PR DESCRIPTION
Close: #944 

This PR introduced 3 behaviors to work around this issue.

1. Download the GeoIP or GeoSite to a temporary file and make sure it is loadable before moving it to the destination.
2. Re-download the GeoIP or GeoSite database if it exists but cannot be loaded.
3. In the case of download failure, instead of exiting with an error, fallback to the previous download as long as it available.