### PR TITLE
Support range format ProtoPort

### DIFF
--- a/extras/outbounds/acl/compile.go
+++ b/extras/outbounds/acl/compile.go
@@ -102,8 +102,8 @@ type GeoLoader interface {
 // Compile compiles TextRules into a CompiledRuleSet.
 // Names in the outbounds map MUST be in all lower case.
 // We want on-demand loading of GeoIP/GeoSite databases, so instead of passing the
-// databases directly, we use a GeoLoader interface to load them. This way, they are
-// only loaded when there are at least one rule that uses them.
+// databases directly, we use a GeoLoader interface to load them only when needed
+// by at least one rule.
 func Compile[O Outbound](rules []TextRule, outbounds map[string]O,
 	cacheSize int, geoLoader GeoLoader,
 ) (CompiledRuleSet[O], error) {

--- a/extras/outbounds/acl/compile.go
+++ b/extras/outbounds/acl/compile.go
@@ -42,7 +42,7 @@ type compiledRule[O Outbound] struct {
 	HostMatcher   hostMatcher
 	Protocol      Protocol
 	StartPort     uint16
-	EndPoint      uint16
+	EndPort       uint16
 	HijackAddress net.IP
 }
 
@@ -50,7 +50,7 @@ func (r *compiledRule[O]) Match(host HostInfo, proto Protocol, port uint16) bool
 	if r.Protocol != ProtocolBoth && r.Protocol != proto {
 		return false
 	}
-	if r.StartPort != 0 && (port < r.StartPort || port > r.EndPoint) {
+	if r.StartPort != 0 && (port < r.StartPort || port > r.EndPort) {
 		return false
 	}
 	return r.HostMatcher.Match(host)

--- a/extras/outbounds/acl/compile_test.go
+++ b/extras/outbounds/acl/compile_test.go
@@ -303,3 +303,76 @@ func Test_parseGeoSiteName(t *testing.T) {
 		})
 	}
 }
+
+func Test_splitPortRangeRules(t *testing.T) {
+	rules := []TextRule{
+		{
+			Outbound:      "ob1",
+			Address:       "1.2.3.4",
+			ProtoPort:     "tcp/1-1024",
+			HijackAddress: "",
+		},
+		{
+			Outbound:      "ob1",
+			Address:       "1.2.3.4",
+			ProtoPort:     "udp/1-1024",
+			HijackAddress: "",
+		},
+		{
+			Outbound:      "ob1",
+			Address:       "1.2.3.4",
+			ProtoPort:     "*/1-1024",
+			HijackAddress: "",
+		},
+		{
+			Outbound:      "ob1",
+			Address:       "1.2.3.4",
+			ProtoPort:     "tcp/0-222",
+			HijackAddress: "",
+		},
+		{
+			Outbound:      "ob1",
+			Address:       "1.2.3.4",
+			ProtoPort:     "tcp/1024",
+			HijackAddress: "",
+		},
+		{
+			Outbound:      "ob1",
+			Address:       "1.2.3.4",
+			ProtoPort:     "tcp/-1-9",
+			HijackAddress: "",
+		},
+		{
+			Outbound:      "ob1",
+			Address:       "1.2.3.4",
+			ProtoPort:     "tcp/6881-6889",
+			HijackAddress: "",
+		},
+	}
+	_, rangeLen0 := splitPortRangeRules(&rules[0])
+	assert.Equal(t, 1023, rangeLen0)
+
+	_, rangeLen1 := splitPortRangeRules(&rules[1])
+	assert.Equal(t, 1023, rangeLen1)
+
+	_, rangeLen2 := splitPortRangeRules(&rules[2])
+	assert.Equal(t, 1023, rangeLen2)
+
+	_, rangeLen3 := splitPortRangeRules(&rules[3])
+	assert.Equal(t, 0, rangeLen3)
+
+	_, rangeLen4 := splitPortRangeRules(&rules[4])
+	assert.Equal(t, 0, rangeLen4)
+
+	_, rangeLen5 := splitPortRangeRules(&rules[5])
+	assert.Equal(t, 0, rangeLen5)
+
+	rangeRule, _ := splitPortRangeRules(&rules[6])
+	for _, rule := range rangeRule {
+		assert.Equal(t, "ob1", rule.Outbound)
+		assert.Equal(t, "1.2.3.4", rule.Address)
+		t.Log(rule.ProtoPort)
+		assert.Equal(t, "", rule.HijackAddress)
+	}
+	assert.Equal(t, "tcp/6881", rules[6].ProtoPort)
+}

--- a/extras/outbounds/acl/compile_test.go
+++ b/extras/outbounds/acl/compile_test.go
@@ -342,7 +342,6 @@ func TestCompileRangePort(t *testing.T) {
 
 	ob11 := 1
 	rules2 := []TextRule{
-
 		{
 			Outbound:      "ob11",
 			Address:       "1.1.2.0/24",
@@ -358,7 +357,6 @@ func TestCompileRangePort(t *testing.T) {
 
 	ob21 := 1
 	rules3 := []TextRule{
-
 		{
 			Outbound:      "ob21",
 			Address:       "1.1.2.0/24",
@@ -371,5 +369,4 @@ func TestCompileRangePort(t *testing.T) {
 		"ob21": ob21,
 	}, 100, &testGeoLoader{})
 	assert.Error(t, err)
-
 }

--- a/extras/outbounds/acl/compile_test.go
+++ b/extras/outbounds/acl/compile_test.go
@@ -269,7 +269,6 @@ func TestCompile(t *testing.T) {
 	// Test Invalid Port Range Rule
 	eb1 := 1
 	invalidRules := []TextRule{
-
 		{
 			Outbound:      "eb1",
 			Address:       "1.1.2.0/24",

--- a/extras/outbounds/acl/compile_test.go
+++ b/extras/outbounds/acl/compile_test.go
@@ -22,7 +22,7 @@ func (l *testGeoLoader) LoadGeoSite() (map[string]*v2geo.GeoSite, error) {
 }
 
 func TestCompile(t *testing.T) {
-	ob1, ob2, ob3, ob4, ob5 := 1, 2, 3, 4, 5
+	ob1, ob2, ob3, ob4, ob5, ob6 := 1, 2, 3, 4, 5, 6
 	rules := []TextRule{
 		{
 			Outbound:      "ob1",
@@ -90,6 +90,12 @@ func TestCompile(t *testing.T) {
 			ProtoPort:     "*/*",
 			HijackAddress: "",
 		},
+		{
+			Outbound:      "ob6",
+			Address:       "all",
+			ProtoPort:     "tcp/6881-6889",
+			HijackAddress: "",
+		},
 	}
 	comp, err := Compile[int](rules, map[string]int{
 		"ob1": ob1,
@@ -97,6 +103,7 @@ func TestCompile(t *testing.T) {
 		"ob3": ob3,
 		"ob4": ob4,
 		"ob5": ob5,
+		"ob6": ob6,
 	}, 100, &testGeoLoader{})
 	assert.NoError(t, err)
 
@@ -242,6 +249,15 @@ func TestCompile(t *testing.T) {
 			wantOutbound: 0, // no match default
 			wantIP:       nil,
 		},
+		{
+			host: HostInfo{
+				IPv4: net.ParseIP("223.1.1.1"),
+			},
+			proto:        ProtocolTCP,
+			port:         6883,
+			wantOutbound: ob6, // match range port rule 6881-6889
+			wantIP:       nil,
+		},
 	}
 
 	for _, test := range tests {
@@ -249,6 +265,23 @@ func TestCompile(t *testing.T) {
 		assert.Equal(t, test.wantOutbound, gotOutbound)
 		assert.Equal(t, test.wantIP, gotIP)
 	}
+
+	// Test Invalid Port Range Rule
+	eb1 := 1
+	invalidRules := []TextRule{
+
+		{
+			Outbound:      "eb1",
+			Address:       "1.1.2.0/24",
+			ProtoPort:     "*/3-1",
+			HijackAddress: "",
+		},
+	}
+
+	_, err = Compile[int](invalidRules, map[string]int{
+		"eb1": eb1,
+	}, 100, &testGeoLoader{})
+	assert.Error(t, err)
 }
 
 func Test_parseGeoSiteName(t *testing.T) {
@@ -302,71 +335,4 @@ func Test_parseGeoSiteName(t *testing.T) {
 			assert.Equalf(t, tt.want1, got1, "parseGeoSiteName(%v)", tt.s)
 		})
 	}
-}
-
-func TestCompileRangePort(t *testing.T) {
-	ob1, ob2, ob3, ob4 := 1, 2, 3, 4
-	rules := []TextRule{
-		{
-			Outbound:      "ob1",
-			Address:       "1.2.3.4",
-			ProtoPort:     "tcp/6881-6889",
-			HijackAddress: "",
-		},
-		{
-			Outbound:      "ob2",
-			Address:       "8.8.8.0/24",
-			ProtoPort:     "udp/2525-3333",
-			HijackAddress: "1.1.1.1",
-		},
-		{
-			Outbound:      "ob3",
-			Address:       "1.1.1.0/24",
-			ProtoPort:     "*/1-65535",
-			HijackAddress: "",
-		},
-		{
-			Outbound:      "ob4",
-			Address:       "1.1.1.0/24",
-			ProtoPort:     "*/22",
-			HijackAddress: "",
-		},
-	}
-	_, err := Compile[int](rules, map[string]int{
-		"ob1": ob1,
-		"ob2": ob2,
-		"ob3": ob3,
-		"ob4": ob4,
-	}, 100, &testGeoLoader{})
-	assert.NoError(t, err)
-
-	ob11 := 1
-	rules2 := []TextRule{
-		{
-			Outbound:      "ob11",
-			Address:       "1.1.2.0/24",
-			ProtoPort:     "*/3-1", // invalid range
-			HijackAddress: "",
-		},
-	}
-
-	_, err = Compile[int](rules2, map[string]int{
-		"ob11": ob11,
-	}, 100, &testGeoLoader{})
-	assert.Error(t, err)
-
-	ob21 := 1
-	rules3 := []TextRule{
-		{
-			Outbound:      "ob21",
-			Address:       "1.1.2.0/24",
-			ProtoPort:     "*/-114-514", // invalid range
-			HijackAddress: "",
-		},
-	}
-
-	_, err = Compile[int](rules3, map[string]int{
-		"ob21": ob21,
-	}, 100, &testGeoLoader{})
-	assert.Error(t, err)
 }


### PR DESCRIPTION
Enable the ProtoPort parameter to support range formats when the user inputs as follows:
```
reject(all, tcp/1022-1024)
```
It will works as 3 rules below:
```
reject(all, tcp/1022) 
reject(all, tcp/1023) 
reject(all, tcp/1024)
```

This feature is particularly beneficial for blocking a wide range of contiguous ports.

```
# Ban Bittorrent Protocol
- reject(all, tcp/6969)
- reject(all, tcp/6881-6889)
- reject(all, tcp/10001-65535)
```
