### PR TITLE
chore(scripts): run apt update on apt based distro

### DIFF
--- a/scripts/install_server.sh
+++ b/scripts/install_server.sh
@@ -236,6 +236,7 @@ detect_package_manager() {
   fi
 
   if has_command apt; then
+    apt update
     PACKAGE_MANAGEMENT_INSTALL='apt -y --no-install-recommends install'
     return 0
   fi


### PR DESCRIPTION
Running apt update to avoid "package not found" error on some pre-installed Ubuntu / Debian.
    
I have tested that other supported Linux distributions do not need this.

| Package Manager | Behavior |
|-----------------|----------|
| dnf/yum/zypper  | Update metadata regularly by default, and checked when installing any package |
| pacman | We run it with -Sy so metadata is always updated |
    
cherry-picked from: apernet/tcp-brutal@efcc08b936dec95a7f4645bb82d501784b21b156
Reference: apernet/tcp-brutal#16

This PR is created as the "Protect master" policy is enforced on this repository.