### PR TITLE
fix(client/http): ffmpeg not works with proxy

### DIFF
--- a/app/internal/http/server.go
+++ b/app/internal/http/server.go
@@ -279,8 +279,10 @@ func sendSimpleResponse(conn net.Conn, req *http.Request, statusCode int) error 
 		Header:     http.Header{},
 	}
 	// Remove the "Content-Length: 0" header, some clients (e.g. ffmpeg) may not like it.
-	// NOTE: This will also cause go/http to add a "Connection: close" header, but seems to be fine.
 	resp.ContentLength = -1
+	// Also, prevent the "Connection: close" header.
+	resp.Close = false
+	resp.Uncompressed = true
 	return resp.Write(conn)
 }
 

--- a/app/internal/http/server.go
+++ b/app/internal/http/server.go
@@ -278,6 +278,9 @@ func sendSimpleResponse(conn net.Conn, req *http.Request, statusCode int) error 
 		ProtoMinor: req.ProtoMinor,
 		Header:     http.Header{},
 	}
+	// Remove the "Content-Length: 0" header, some clients (e.g. ffmpeg) may not like it.
+	// NOTE: This will also cause go/http to add a "Connection: close" header, but seems to be fine.
+	resp.ContentLength = -1
 	return resp.Write(conn)
 }
 


### PR DESCRIPTION
Go's resp.Write() adds a "Content-Length: 0" header and it seems that ffmpeg doesn't like this and immediately closes the proxy connection.

close: #1109