### PR TITLE
fix escaped auth

### DIFF
--- a/app/cmd/client.go
+++ b/app/cmd/client.go
@@ -393,7 +393,11 @@ func (c *clientConfig) parseURI() bool {
 		return false
 	}
 	if u.User != nil {
-		c.Auth = u.User.String()
+		auth, err := url.QueryUnescape(u.User.String())
+		if err != nil {
+			return false
+		}
+		c.Auth = auth
 	}
 	c.Server = u.Host
 	q := u.Query()


### PR DESCRIPTION
When calling `func (c *clientConfig) URI() string` to generate hysteria2 share links, the **Auth** is escaped. But when calling `func (c *clientConfig) parseURI() bool` to parse hysteria2 share links, the **Auth** is NOT unescaped.