### PR TITLE
fix(scripts): detect selinux with getenforce

### DIFF
--- a/scripts/install_server.sh
+++ b/scripts/install_server.sh
@@ -465,7 +465,7 @@ check_environment_systemd() {
 }
 
 check_environment_selinux() {
-  if ! has_command chcon; then
+  if ! has_command getenforce; then
     return
   fi
 


### PR DESCRIPTION
`chcon` is widely available in coreutils, even if the system doesn't support selinux.