### PR TITLE
fix: quic sniff not work if udp msg fragmentated

### DIFF
--- a/core/internal/integration_tests/hook_test.go
+++ b/core/internal/integration_tests/hook_test.go
@@ -132,7 +132,9 @@ func TestClientServerHookUDP(t *testing.T) {
 	rData, rAddr, err := conn.Receive()
 	assert.NoError(t, err)
 	assert.Equal(t, sData, rData)
-	assert.Equal(t, realEchoAddr, rAddr)
+	// Hook address change is transparent,
+	// the client should still see the fake echo address it sent packets to
+	assert.Equal(t, fakeEchoAddr, rAddr)
 
 	// Subsequent packets should also be sent to the real echo server
 	sData = []byte("never stop fighting")
@@ -141,5 +143,5 @@ func TestClientServerHookUDP(t *testing.T) {
 	rData, rAddr, err = conn.Receive()
 	assert.NoError(t, err)
 	assert.Equal(t, sData, rData)
-	assert.Equal(t, realEchoAddr, rAddr)
+	assert.Equal(t, fakeEchoAddr, rAddr)
 }

--- a/core/server/udp.go
+++ b/core/server/udp.go
@@ -133,7 +133,9 @@ func (e *udpSessionEntry) initConn(firstMsg *protocol.UDPMessage) error {
 	}
 
 	e.conn = conn
+
 	if firstMsg.Addr != actualAddr {
+		// Hook changed the address, enable address override
 		e.OverrideAddr = actualAddr
 		e.OriginalAddr = firstMsg.Addr
 	}


### PR DESCRIPTION
ref: https://github.com/apernet/hysteria/discussions/1204#discussioncomment-10702442

This PR rewrites `udpSessionEntry` and `udpSessionManager.feed()` to ensure sniffer is called with reassembled first packet.