### PR TITLE
fix: check the URL scheme of `masquerade.proxy.url` in server config

### DIFF
--- a/app/cmd/server.go
+++ b/app/cmd/server.go
@@ -804,6 +804,9 @@ func (c *serverConfig) fillMasqHandler(hyConfig *server.Config) error {
 		if err != nil {
 			return configError{Field: "masquerade.proxy.url", Err: err}
 		}
+		if u.Scheme != "http" && u.Scheme != "https" {
+			return configError{Field: "masquerade.proxy.url", Err: fmt.Errorf("unsupported protocol scheme \"%s\"", u.Scheme)}
+		}
 		handler = &httputil.ReverseProxy{
 			Rewrite: func(r *httputil.ProxyRequest) {
 				r.SetURL(u)


### PR DESCRIPTION
Check the URL scheme of `masquerade.proxy.url` when parsing server config and fail fast if it is not `"http"` or `"https"`.

ref: #1227

The user assigned the URL with a naked hostname and got no errors until the request was handled.