### PR TITLE
feat: add toolchain & quic-go to version info

### DIFF
--- a/app/cmd/root.go
+++ b/app/cmd/root.go
@@ -29,20 +29,24 @@ const (
 
 var (
 	// These values will be injected by the build system
-	appVersion  = "Unknown"
-	appDate     = "Unknown"
-	appType     = "Unknown" // aka channel
-	appCommit   = "Unknown"
-	appPlatform = "Unknown"
-	appArch     = "Unknown"
+	appVersion   = "Unknown"
+	appDate      = "Unknown"
+	appType      = "Unknown" // aka channel
+	appToolchain = "Unknown"
+	appCommit    = "Unknown"
+	appPlatform  = "Unknown"
+	appArch      = "Unknown"
+	libVersion   = "Unknown"
 
 	appVersionLong = fmt.Sprintf("Version:\t%s\n"+
 		"BuildDate:\t%s\n"+
 		"BuildType:\t%s\n"+
+		"Toolchain:\t%s\n"+
 		"CommitHash:\t%s\n"+
 		"Platform:\t%s\n"+
-		"Architecture:\t%s",
-		appVersion, appDate, appType, appCommit, appPlatform, appArch)
+		"Architecture:\t%s\n"+
+		"LibVersion:\t%s",
+		appVersion, appDate, appType, appToolchain, appCommit, appPlatform, appArch, libVersion)
 
 	appAboutLong = fmt.Sprintf("%s\n%s\n%s\n\n%s", appLogo, appDesc, appAuthors, appVersionLong)
 )

--- a/scripts/install_server.sh
+++ b/scripts/install_server.sh
@@ -872,7 +872,7 @@ is_hysteria1_version() {
 get_installed_version() {
   if is_hysteria_installed; then
     if "$EXECUTABLE_INSTALL_PATH" version > /dev/null 2>&1; then
-      "$EXECUTABLE_INSTALL_PATH" version | grep Version | grep -o 'v[.0-9]*'
+      "$EXECUTABLE_INSTALL_PATH" version | grep '^Version' | grep -o 'v[.0-9]*'
     elif "$EXECUTABLE_INSTALL_PATH" -v > /dev/null 2>&1; then
       # hysteria 1
       "$EXECUTABLE_INSTALL_PATH" -v | cut -d ' ' -f 3


### PR DESCRIPTION
Sample output:

```

░█░█░█░█░█▀▀░▀█▀░█▀▀░█▀▄░▀█▀░█▀█░░░▀▀▄
░█▀█░░█░░▀▀█░░█░░█▀▀░█▀▄░░█░░█▀█░░░▄▀░
░▀░▀░░▀░░▀▀▀░░▀░░▀▀▀░▀░▀░▀▀▀░▀░▀░░░▀▀▀

a powerful, lightning fast and censorship resistant proxy
Aperture Internet Laboratory <https://github.com/apernet>

Version:        v2.5.2-8-ga2c7b8f
BuildDate:      2024-11-04T19:57:56Z
BuildType:      dev-run
Toolchain:      go1.23.2 windows/amd64
CommitHash:     a2c7b8fd198dc6d8240d60b7561158f3c3f7dc74
Platform:       windows
Architecture:   amd64
LibVersion:     v0.47.1-0.20241004180137-a80d14e2080d
```