### PR TITLE
chore(version): rename LibVersion to Libraries

### DIFF
--- a/app/cmd/root.go
+++ b/app/cmd/root.go
@@ -45,7 +45,7 @@ var (
 		"CommitHash:\t%s\n"+
 		"Platform:\t%s\n"+
 		"Architecture:\t%s\n"+
-		"LibVersion:\t%s",
+		"Libraries:\tquic-go=%s",
 		appVersion, appDate, appType, appToolchain, appCommit, appPlatform, appArch, libVersion)
 
 	appAboutLong = fmt.Sprintf("%s\n%s\n%s\n\n%s", appLogo, appDesc, appAuthors, appVersionLong)


### PR DESCRIPTION
close: #1271

A key that also contains "Version" broke the version parsing of some third-party clients.

```
./hyperbole.py run version

░█░█░█░█░█▀▀░▀█▀░█▀▀░█▀▄░▀█▀░█▀█░░░▀▀▄
░█▀█░░█░░▀▀█░░█░░█▀▀░█▀▄░░█░░█▀█░░░▄▀░
░▀░▀░░▀░░▀▀▀░░▀░░▀▀▀░▀░▀░▀▀▀░▀░▀░░░▀▀▀

a powerful, lightning fast and censorship resistant proxy
Aperture Internet Laboratory <https://github.com/apernet>

Version:        v2.6.0-5-g400fed3
BuildDate:      2024-12-11T09:09:43Z
BuildType:      dev-run
Toolchain:      go1.23.2 linux/amd64
CommitHash:     400fed3bd607d5f529487aa07d7f4d630c802ae4
Platform:       linux
Architecture:   amd64
Libraries:      quic-go=v0.48.2-0.20241104191913-cb103fcecfe7
```