### PR TITLE
Make username of userpass case insensitive

### DIFF
--- a/app/cmd/server.go
+++ b/app/cmd/server.go
@@ -755,7 +755,7 @@ func (c *serverConfig) fillAuthenticator(hyConfig *server.Config) error {
 		if len(c.Auth.UserPass) == 0 {
 			return configError{Field: "auth.userpass", Err: errors.New("empty auth userpass")}
 		}
-		hyConfig.Authenticator = &auth.UserPassAuthenticator{Users: c.Auth.UserPass}
+		hyConfig.Authenticator = auth.NewUserPassAuthenticator(c.Auth.UserPass)
 		return nil
 	case "http", "https":
 		if c.Auth.HTTP.URL == "" {

--- a/extras/auth/userpass.go
+++ b/extras/auth/userpass.go
@@ -16,7 +16,7 @@ var _ server.Authenticator = &UserPassAuthenticator{}
 // UserPassAuthenticator checks the provided auth string against a map of username/password pairs.
 // The format of the auth string must be "username:password".
 type UserPassAuthenticator struct {
-	Users map[string]string
+	users map[string]string
 }
 
 func NewUserPassAuthenticator(users map[string]string) *UserPassAuthenticator {
@@ -26,7 +26,7 @@ func NewUserPassAuthenticator(users map[string]string) *UserPassAuthenticator {
 	for user, pass := range users {
 		lcUsers[strings.ToLower(user)] = pass
 	}
-	return &UserPassAuthenticator{Users: lcUsers}
+	return &UserPassAuthenticator{users: lcUsers}
 }
 
 func (a *UserPassAuthenticator) Authenticate(addr net.Addr, auth string, tx uint64) (ok bool, id string) {
@@ -34,7 +34,7 @@ func (a *UserPassAuthenticator) Authenticate(addr net.Addr, auth string, tx uint
 	if !ok {
 		return false, ""
 	}
-	rp, ok := a.Users[u]
+	rp, ok := a.users[u]
 	if !ok || rp != p {
 		return false, ""
 	}

--- a/extras/auth/userpass.go
+++ b/extras/auth/userpass.go
@@ -19,6 +19,16 @@ type UserPassAuthenticator struct {
 	Users map[string]string
 }
 
+func NewUserPassAuthenticator(users map[string]string) *UserPassAuthenticator {
+	// Usernames are case-insensitive, as they are already lowercased by viper.
+	// Lowercase it again on our own to make it explicit.
+	lcUsers := make(map[string]string, len(users))
+	for user, pass := range users {
+		lcUsers[strings.ToLower(user)] = pass
+	}
+	return &UserPassAuthenticator{Users: lcUsers}
+}
+
 func (a *UserPassAuthenticator) Authenticate(addr net.Addr, auth string, tx uint64) (ok bool, id string) {
 	u, p, ok := splitUserPass(auth)
 	if !ok {
@@ -36,5 +46,6 @@ func splitUserPass(auth string) (user, pass string, ok bool) {
 	if len(rs) != 2 {
 		return "", "", false
 	}
-	return rs[0], rs[1], true
+	// Usernames are case-insensitive
+	return strings.ToLower(rs[0]), rs[1], true
 }

--- a/extras/auth/userpass_test.go
+++ b/extras/auth/userpass_test.go
@@ -85,12 +85,26 @@ func TestUserPassAuthenticator(t *testing.T) {
 			wantOk: false,
 			wantId: "",
 		},
+		{
+			name: "case insensitive username",
+			fields: fields{
+				Users: map[string]string{
+					"gawR":   "gura",
+					"fubuki": "shirakami",
+				},
+			},
+			args: args{
+				addr: nil,
+				auth: "Gawr:gura",
+				tx:   0,
+			},
+			wantOk: true,
+			wantId: "gawr",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			a := &UserPassAuthenticator{
-				Users: tt.fields.Users,
-			}
+			a := NewUserPassAuthenticator(tt.fields.Users)
 			gotOk, gotId := a.Authenticate(tt.args.addr, tt.args.auth, tt.args.tx)
 			if gotOk != tt.wantOk {
 				t.Errorf("Authenticate() gotOk = %v, want %v", gotOk, tt.wantOk)


### PR DESCRIPTION
close: #1297

Just a workaround for "uppercase usernames do not work".

Usernames in different cases (like "Gawr" and "gawR") will now conflict.
However, such conflicts are still not reported as errors, which seems impossible while we are still using viper.

External authentication using HTTP or command is not affected by this PR.

We also need to update docs for userpass.