### PR TITLE
fix(client): remove share uri in log

### DIFF
--- a/app/cmd/client.go
+++ b/app/cmd/client.go
@@ -470,8 +470,10 @@ func runClient(cmd *cobra.Command, args []string) {
 	defer c.Close()
 
 	uri := config.URI()
-	logger.Info("use this URI to share your server", zap.String("uri", uri))
 	if showQR {
+		logger.Warn("--qr flag is deprecated and will be removed in future release, " +
+			"please use `share` subcommand to generate share URI and QR code")
+		logger.Info("use this URI to share your server", zap.String("uri", uri))
 		utils.PrintQR(uri)
 	}
 


### PR DESCRIPTION
Close: #1355

Since we already have the `share` subcommand, this feature is unnecessary for the `client` subcommand.

This commit disables printing the share URI after the client starts, but keeps this behavior for users who specified the `--qr` flag (who may still rely on it) and shows a deprecation warning.