### PR TITLE
feat(auth): add client ID to HTTP authentication requests

### DIFF
--- a/extras/auth/clientid.go
+++ b/extras/auth/clientid.go
@@ -1,0 +1,71 @@
+package auth
+
+import (
+	"crypto/md5"
+	"crypto/sha256"
+	"encoding/hex"
+	"net"
+	"os"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+)
+
+var (
+	clientIDOnce sync.Once
+	clientID     string
+)
+
+// GetClientID returns a unique client ID based on hardware information.
+// The ID is generated once and cached for subsequent calls.
+func GetClientID() string {
+	clientIDOnce.Do(func() {
+		clientID = generateClientID()
+	})
+	return clientID
+}
+
+// generateClientID creates a unique client ID based on available hardware information
+func generateClientID() string {
+	var identifiers []string
+
+	// Get MAC addresses from all network interfaces
+	if interfaces, err := net.Interfaces(); err == nil {
+		var macAddresses []string
+		for _, iface := range interfaces {
+			// Skip loopback and down interfaces
+			if iface.Flags&net.FlagLoopback != 0 || iface.Flags&net.FlagUp == 0 {
+				continue
+			}
+			if len(iface.HardwareAddr) > 0 {
+				macAddresses = append(macAddresses, iface.HardwareAddr.String())
+			}
+		}
+		// Sort MAC addresses for consistency
+		sort.Strings(macAddresses)
+		if len(macAddresses) > 0 {
+			identifiers = append(identifiers, strings.Join(macAddresses, ","))
+		}
+	}
+
+	// Add hostname
+	if hostname, err := os.Hostname(); err == nil && hostname != "" {
+		identifiers = append(identifiers, hostname)
+	}
+
+	// Add OS and architecture information
+	identifiers = append(identifiers, runtime.GOOS)
+	identifiers = append(identifiers, runtime.GOARCH)
+
+	// Combine all identifiers
+	combined := strings.Join(identifiers, "|")
+
+	// Generate a hash of the combined identifiers
+	hash := sha256.Sum256([]byte(combined))
+
+	// Use first 16 bytes for a shorter ID
+	shortHash := md5.Sum(hash[:16])
+
+	return hex.EncodeToString(shortHash[:])
+}

--- a/extras/auth/http.go
+++ b/extras/auth/http.go
@@ -41,9 +41,10 @@ func NewHTTPAuthenticator(url string, insecure bool) *HTTPAuthenticator {
 }
 
 type httpAuthRequest struct {
-	Addr string `json:"addr"`
-	Auth string `json:"auth"`
-	Tx   uint64 `json:"tx"`
+	Addr     string `json:"addr"`
+	Auth     string `json:"auth"`
+	Tx       uint64 `json:"tx"`
+	ClientID string `json:"client_id"`
 }
 
 type httpAuthResponse struct {
@@ -78,9 +79,10 @@ func (a *HTTPAuthenticator) post(req *httpAuthRequest) (*httpAuthResponse, error
 
 func (a *HTTPAuthenticator) Authenticate(addr net.Addr, auth string, tx uint64) (ok bool, id string) {
 	req := &httpAuthRequest{
-		Addr: addr.String(),
-		Auth: auth,
-		Tx:   tx,
+		Addr:     addr.String(),
+		Auth:     auth,
+		Tx:       tx,
+		ClientID: GetClientID(),
 	}
 	resp, err := a.post(req)
 	if err != nil {


### PR DESCRIPTION
- Add client_id field to httpAuthRequest struct
- Implement hardware-based client ID generation using MAC addresses, hostname, OS and architecture
- Client ID is generated once and cached for subsequent requests
- Enable differentiation between different devices for the same user