### PR TITLE
Add optional mTLS support for client & server

### DIFF
--- a/app/cmd/client.go
+++ b/app/cmd/client.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"crypto/sha256"
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/hex"
 	"errors"
@@ -96,10 +97,12 @@ type clientConfigObfs struct {
 }
 
 type clientConfigTLS struct {
-	SNI       string `mapstructure:"sni"`
-	Insecure  bool   `mapstructure:"insecure"`
-	PinSHA256 string `mapstructure:"pinSHA256"`
-	CA        string `mapstructure:"ca"`
+	SNI               string `mapstructure:"sni"`
+	Insecure          bool   `mapstructure:"insecure"`
+	PinSHA256         string `mapstructure:"pinSHA256"`
+	CA                string `mapstructure:"ca"`
+	ClientCertificate string `mapstructure:"clientCertificate"`
+	ClientKey         string `mapstructure:"clientKey"`
 }
 
 type clientConfigQUIC struct {
@@ -293,6 +296,31 @@ func (c *clientConfig) fillTLSConfig(hyConfig *client.Config) error {
 			return configError{Field: "tls.ca", Err: errors.New("failed to parse CA certificate")}
 		}
 		hyConfig.TLSConfig.RootCAs = cPool
+	}
+	if c.TLS.ClientCertificate != "" && c.TLS.ClientKey != "" {
+		certLoader := &utils.LocalCertificateLoader{
+			CertFile: c.TLS.ClientCertificate,
+			KeyFile:  c.TLS.ClientKey,
+		}
+		// Try loading the cert-key pair here to catch errors early
+		err := certLoader.InitializeCache()
+		if err != nil {
+			var pathErr *os.PathError
+			if errors.As(err, &pathErr) {
+				if pathErr.Path == c.TLS.ClientCertificate {
+					return configError{Field: "tls.clientCertificate", Err: pathErr}
+				}
+				if pathErr.Path == c.TLS.ClientKey {
+					return configError{Field: "tls.clientKey", Err: pathErr}
+				}
+			}
+			return configError{Field: "tls.clientCertificate", Err: err}
+		}
+		// Use GetClientCertificates so that users can update the cert without restarting the client.
+		hyConfig.TLSConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			// For simplicity, always respond with the configured client certs, regardless of server requests.
+			return certLoader.GetCertificate(nil)
+		}
 	}
 	return nil
 }

--- a/app/cmd/client_test.go
+++ b/app/cmd/client_test.go
@@ -33,10 +33,12 @@ func TestClientConfig(t *testing.T) {
 			},
 		},
 		TLS: clientConfigTLS{
-			SNI:       "another.example.com",
-			Insecure:  true,
-			PinSHA256: "114515DEADBEEF",
-			CA:        "custom_ca.crt",
+			SNI:               "another.example.com",
+			Insecure:          true,
+			PinSHA256:         "114515DEADBEEF",
+			CA:                "custom_ca.crt",
+			ClientCertificate: "client.crt",
+			ClientKey:         "client.key",
 		},
 		QUIC: clientConfigQUIC{
 			InitStreamReceiveWindow:     1145141,

--- a/app/cmd/client_test.yaml
+++ b/app/cmd/client_test.yaml
@@ -17,6 +17,8 @@ tls:
   insecure: true
   pinSHA256: 114515DEADBEEF
   ca: custom_ca.crt
+  clientCertificate: client.crt
+  clientKey: client.key
 
 quic:
   initStreamReceiveWindow: 1145141

--- a/app/cmd/server_test.go
+++ b/app/cmd/server_test.go
@@ -29,6 +29,7 @@ func TestServerConfig(t *testing.T) {
 			Cert:     "some.crt",
 			Key:      "some.key",
 			SNIGuard: "strict",
+			ClientCA: "some_ca.crt",
 		},
 		ACME: &serverConfigACME{
 			Domains: []string{

--- a/app/cmd/server_test.yaml
+++ b/app/cmd/server_test.yaml
@@ -9,6 +9,7 @@ tls:
   cert: some.crt
   key: some.key
   sniGuard: strict
+  clientCA: some_ca.crt
 
 acme:
   domains:

--- a/core/client/client.go
+++ b/core/client/client.go
@@ -74,6 +74,7 @@ func (c *clientImpl) connect() (*HandshakeInfo, error) {
 		InsecureSkipVerify:    c.config.TLSConfig.InsecureSkipVerify,
 		VerifyPeerCertificate: c.config.TLSConfig.VerifyPeerCertificate,
 		RootCAs:               c.config.TLSConfig.RootCAs,
+		GetClientCertificate:  c.config.TLSConfig.GetClientCertificate,
 	}
 	quicConfig := &quic.Config{
 		InitialStreamReceiveWindow:     c.config.QUICConfig.InitialStreamReceiveWindow,

--- a/core/client/config.go
+++ b/core/client/config.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"crypto/tls"
 	"crypto/x509"
 	"net"
 	"time"
@@ -92,6 +93,7 @@ type TLSConfig struct {
 	InsecureSkipVerify    bool
 	VerifyPeerCertificate func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error
 	RootCAs               *x509.CertPool
+	GetClientCertificate  func(*tls.CertificateRequestInfo) (*tls.Certificate, error)
 }
 
 // QUICConfig contains the QUIC configuration fields that we want to expose to the user.

--- a/core/server/config.go
+++ b/core/server/config.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"net"
 	"net/http"
 	"sync/atomic"
@@ -101,6 +102,7 @@ func (c *Config) fill() error {
 type TLSConfig struct {
 	Certificates   []tls.Certificate
 	GetCertificate func(info *tls.ClientHelloInfo) (*tls.Certificate, error)
+	ClientCAs      *x509.CertPool
 }
 
 // QUICConfig contains the QUIC configuration fields that we want to expose to the user.


### PR DESCRIPTION
This PR adds optional mutual TLS support to Hysteria.

Motivation:

While Hysteria2 is original designed to bypass censorship, it can be run as a regular VPN too. Recently I have been trying to connect my IP cameras to the Internet with a middle layer to ensure security. Initially I tried WireGuard but I could barely view the audio stream in the 480P resolution. Then I replaced it with Hy2, and I can now watch the video stream in the 4K resolution.

A small minus for the Hy2 setup is the security of the client authentication. Traditional VPNs such as WireGuard, Zerotier, OpenVPN, OpenConnect, IKEv2, etc, have public-private key based client authentication, but Hy2 lacks it. This simple PR can fix that, so we can have the best of both worlds, speed and security, in one binary.