### PR TITLE
fix: remove license-conflicted doh library

### DIFF
--- a/app/go.mod
+++ b/app/go.mod
@@ -31,7 +31,6 @@ require (
 require (
 	github.com/andybalholm/brotli v1.1.0 // indirect
 	github.com/apernet/quic-go v0.52.1-0.20250607183305-9320c9d14431 // indirect
-	github.com/babolivier/go-doh-client v0.0.0-20201028162107-a76cff4cb8b6 // indirect
 	github.com/cloudflare/circl v1.3.9 // indirect
 	github.com/database64128/netx-go v0.0.0-20240905055117-62795b8b054a // indirect
 	github.com/database64128/tfo-go/v2 v2.2.2 // indirect

--- a/app/go.sum
+++ b/app/go.sum
@@ -46,8 +46,6 @@ github.com/apernet/quic-go v0.52.1-0.20250607183305-9320c9d14431 h1:9/jM7e+kVALd
 github.com/apernet/quic-go v0.52.1-0.20250607183305-9320c9d14431/go.mod h1:I/47OIGG5H/IfAm+nz2c6hm6b/NkEhpvptAoiPcY7jQ=
 github.com/apernet/sing-tun v0.2.6-0.20250726070404-c99085f9af13 h1:gzets97c/u5iMj1zjanMBVkIYOdaVw+RXPzTT1xQoyM=
 github.com/apernet/sing-tun v0.2.6-0.20250726070404-c99085f9af13/go.mod h1:S5IydyLSN/QAfvY+r2GoomPJ6hidtXWm/Ad18sJVssk=
-github.com/babolivier/go-doh-client v0.0.0-20201028162107-a76cff4cb8b6 h1:4NNbNM2Iq/k57qEu7WfL67UrbPq1uFWxW4qODCohi+0=
-github.com/babolivier/go-doh-client v0.0.0-20201028162107-a76cff4cb8b6/go.mod h1:J29hk+f9lJrblVIfiJOtTFk+OblBawmib4uz/VdKzlg=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/caddyserver/certmagic v0.17.2 h1:o30seC1T/dBqBCNNGNHWwj2i5/I/FMjBbTAhjADP3nE=

--- a/extras/go.mod
+++ b/extras/go.mod
@@ -7,7 +7,6 @@ toolchain go1.24.2
 require (
 	github.com/apernet/hysteria/core/v2 v2.0.0-00010101000000-000000000000
 	github.com/apernet/quic-go v0.52.1-0.20250607183305-9320c9d14431
-	github.com/babolivier/go-doh-client v0.0.0-20201028162107-a76cff4cb8b6
 	github.com/database64128/tfo-go/v2 v2.2.2
 	github.com/hashicorp/golang-lru/v2 v2.0.5
 	github.com/miekg/dns v1.1.59

--- a/extras/go.sum
+++ b/extras/go.sum
@@ -2,8 +2,6 @@ github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1
 github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer58Q+mhRPtnY=
 github.com/apernet/quic-go v0.52.1-0.20250607183305-9320c9d14431 h1:9/jM7e+kVALd7Jfu1c27dcEpT/Fd/Gzq2OsQjKjakKI=
 github.com/apernet/quic-go v0.52.1-0.20250607183305-9320c9d14431/go.mod h1:I/47OIGG5H/IfAm+nz2c6hm6b/NkEhpvptAoiPcY7jQ=
-github.com/babolivier/go-doh-client v0.0.0-20201028162107-a76cff4cb8b6 h1:4NNbNM2Iq/k57qEu7WfL67UrbPq1uFWxW4qODCohi+0=
-github.com/babolivier/go-doh-client v0.0.0-20201028162107-a76cff4cb8b6/go.mod h1:J29hk+f9lJrblVIfiJOtTFk+OblBawmib4uz/VdKzlg=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/extras/outbounds/tinydoh/resolver.go
+++ b/extras/outbounds/tinydoh/resolver.go
@@ -1,0 +1,127 @@
+package tinydoh
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+
+	"golang.org/x/net/dns/dnsmessage"
+)
+
+type Resolver struct {
+	URL        string
+	HTTPClient *http.Client
+}
+
+func (r *Resolver) lookup(dnsType dnsmessage.Type, host string) ([]dnsmessage.Resource, error) {
+	url := r.URL
+	if url == "" {
+		return nil, errors.New("no DoH URL provided")
+	}
+	client := r.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	if !strings.HasSuffix(host, ".") {
+		host += "."
+	}
+	name, err := dnsmessage.NewName(host)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse host %s: %w", host, err)
+	}
+
+	reqBuilder := dnsmessage.NewBuilder(nil, dnsmessage.Header{
+		RecursionDesired: true,
+	})
+	reqBuilder.EnableCompression()
+	err = reqBuilder.StartQuestions()
+	if err != nil {
+		return nil, fmt.Errorf("failed to start dns questions for host %s: %w", host, err)
+	}
+	err = reqBuilder.Question(dnsmessage.Question{
+		Name:  name,
+		Type:  dnsType,
+		Class: dnsmessage.ClassINET,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to build dns question for host %s: %w", host, err)
+	}
+	reqMsg, err := reqBuilder.Finish()
+	if err != nil {
+		return nil, fmt.Errorf("failed to finish dns message for host %s: %w", host, err)
+	}
+	httpReq, err := http.NewRequest("POST", url, strings.NewReader(string(reqMsg)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create http request for host %s: %w", host, err)
+	}
+	httpReq.Header.Set("Content-Type", "application/dns-message")
+
+	httpResp, err := client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to perform http request for host %s: %w", host, err)
+	}
+	defer httpResp.Body.Close()
+	if httpResp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("non-200 status-code=%d for host %s", httpResp.StatusCode, host)
+	}
+	if httpResp.Header.Get("Content-Type") != "application/dns-message" {
+		return nil, fmt.Errorf("unexpected content-type=%s for host %s", httpResp.Header.Get("Content-Type"), host)
+	}
+
+	// 64KB should be enough for all DNS response
+	limitedBody := io.LimitReader(httpResp.Body, 65536)
+	respMsg, err := io.ReadAll(limitedBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read http response body for host %s: %w", host, err)
+	}
+	parser := dnsmessage.Parser{}
+	header, err := parser.Start(respMsg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse dns message header for host %s: %w", host, err)
+	}
+	if header.RCode != dnsmessage.RCodeSuccess {
+		return nil, fmt.Errorf("dns query failed with %s for host %s", header.RCode, host)
+	}
+	err = parser.SkipAllQuestions()
+	if err != nil {
+		return nil, fmt.Errorf("failed to skip dns questions for host %s: %w", host, err)
+	}
+	answers, err := parser.AllAnswers()
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse dns answers for host %s: %w", host, err)
+	}
+	return answers, nil
+}
+
+func (r *Resolver) LookupA(host string) ([]net.IP, error) {
+	answers, err := r.lookup(dnsmessage.TypeA, host)
+	if err != nil {
+		return nil, err
+	}
+	var results []net.IP
+	for _, rr := range answers {
+		if rr.Header.Type == dnsmessage.TypeA {
+			a := rr.Body.(*dnsmessage.AResource)
+			results = append(results, a.A[:])
+		}
+	}
+	return results, nil
+}
+
+func (r *Resolver) LookupAAAA(host string) ([]net.IP, error) {
+	answers, err := r.lookup(dnsmessage.TypeAAAA, host)
+	if err != nil {
+		return nil, err
+	}
+	var results []net.IP
+	for _, rr := range answers {
+		if rr.Header.Type == dnsmessage.TypeAAAA {
+			aaaa := rr.Body.(*dnsmessage.AAAAResource)
+			results = append(results, aaaa.AAAA[:])
+		}
+	}
+	return results, nil
+}

--- a/extras/outbounds/tinydoh/resolver_test.go
+++ b/extras/outbounds/tinydoh/resolver_test.go
@@ -1,0 +1,22 @@
+package tinydoh
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestResolver(t *testing.T) {
+	r := &Resolver{
+		URL: "https://1.1.1.1/dns-query",
+	}
+	ipv4, err := r.LookupA("www.wikipedia.org")
+	if err != nil {
+		t.Error(err)
+	}
+	fmt.Println(ipv4)
+	ipv6, err := r.LookupAAAA("www.wikipedia.org")
+	if err != nil {
+		t.Error(err)
+	}
+	fmt.Println(ipv6)
+}


### PR DESCRIPTION
Replace GPL-licensed `github.com/babolivier/go-doh-client` with a homemade `tinydoh` implementation.

This PR actually close a disappeared issue #1411 (Potential GPLv3 License Violation in apernet/hysteria Due to Dependent Libraries).