### PR TITLE
Fix the MITM vulnerability

### DIFF
--- a/app/cmd/client.go
+++ b/app/cmd/client.go
@@ -275,12 +275,11 @@ func (c *clientConfig) fillTLSConfig(hyConfig *client.Config) error {
 	if c.TLS.PinSHA256 != "" {
 		nHash := normalizeCertHash(c.TLS.PinSHA256)
 		hyConfig.TLSConfig.VerifyPeerCertificate = func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
-			for _, cert := range rawCerts {
-				hash := sha256.Sum256(cert)
-				hashHex := hex.EncodeToString(hash[:])
-				if hashHex == nHash {
-					return nil
-				}
+			cert := rawCerts[0] // only check the end-entity cert hash in the chain of trust
+			hash := sha256.Sum256(cert)
+			hashHex := hex.EncodeToString(hash[:])
+			if hashHex == nHash {
+				return nil
 			}
 			// No match
 			return errors.New("no certificate matches the pinned hash")


### PR DESCRIPTION
### Summary

A malicious actor is capable of intercepting QUIC traffic between the client
and the server.

### Details

The attack requires to use certificate pinning with CA-issued certificates. The hysteria client tries to match the pinned hash against every single cert in the certchain. If the client is misconfigured to pin the hash of the CA root cert instead of the end-entity cert this will leak hysteria password in a MITM attack. The server must be configured with a cert-chain, not just an end-entity certificate. Setting sniGuard: disable in the server config allows the attacker to also to analyze the traffic inside the tunnel.