### PR TITLE
Add an option to enable XForwarded headers

### DIFF
--- a/app/cmd/server.go
+++ b/app/cmd/server.go
@@ -238,10 +238,10 @@ type serverConfigMasqueradeFile struct {
 }
 
 type serverConfigMasqueradeProxy struct {
-	URL                     string `mapstructure:"url"`
-	RewriteHost             bool   `mapstructure:"rewriteHost"`
-	EnableXForwardedHeaders bool   `mapstructure:"enableXForwardedHeaders"`
-	Insecure                bool   `mapstructure:"insecure"`
+	URL         string `mapstructure:"url"`
+	RewriteHost bool   `mapstructure:"rewriteHost"`
+	XForwarded  bool   `mapstructure:"xForwarded"`
+	Insecure    bool   `mapstructure:"insecure"`
 }
 
 type serverConfigMasqueradeString struct {
@@ -853,7 +853,7 @@ func (c *serverConfig) fillMasqHandler(hyConfig *server.Config) error {
 				if !c.Masquerade.Proxy.RewriteHost {
 					r.Out.Host = r.In.Host
 				}
-				if c.Masquerade.Proxy.EnableXForwardedHeaders {
+				if c.Masquerade.Proxy.XForwarded {
 					r.SetXForwarded()
 				}
 			},

--- a/app/cmd/server_test.go
+++ b/app/cmd/server_test.go
@@ -170,10 +170,10 @@ func TestServerConfig(t *testing.T) {
 				Dir: "/www/masq",
 			},
 			Proxy: serverConfigMasqueradeProxy{
-				URL:                     "https://some.site.net",
-				RewriteHost:             true,
-				EnableXForwardedHeaders: true,
-				Insecure:                true,
+				URL:         "https://some.site.net",
+				RewriteHost: true,
+				XForwarded:  true,
+				Insecure:    true,
 			},
 			String: serverConfigMasqueradeString{
 				Content: "aint nothin here",

--- a/app/cmd/server_test.yaml
+++ b/app/cmd/server_test.yaml
@@ -133,7 +133,7 @@ masquerade:
   proxy:
     url: https://some.site.net
     rewriteHost: true
-    enableXForwardedHeaders: true
+    xForwarded: true
     insecure: true
   string:
     content: aint nothin here


### PR DESCRIPTION
**Summary**
This PR adds an option for enabling X-Forwarded headers for setups with reverse proxy to your own website.

**Motivation**
When Hysteria acts as a reverse proxy for your own website, all requests currently appear to originate from the proxy IP. 
This breaks some IP-based logic like rate limiting.

Moreover you can configure some logging on the website side to collect connections IPs, and possible detect active probing attempts.
