### PR TITLE
fix(trafficlogger): initialize stats entry for users with zero traffic

### DIFF
--- a/extras/trafficlogger/http.go
+++ b/extras/trafficlogger/http.go
@@ -148,10 +148,10 @@ func (s *trafficStatsServerImpl) getTraffic(w http.ResponseWriter, r *http.Reque
 		s.StatsMap = make(map[string]*trafficStatsEntry)
 		s.Mutex.Unlock()
 	} else {
-		s.Mutex.RLock()
+		s.Mutex.Lock()
 		s.fillMissingStats()
 		jb, err = json.Marshal(s.StatsMap)
-		s.Mutex.RUnlock()
+		s.Mutex.Unlock()
 	}
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
Initialize traffic stats entry when user comes online to ensure users with zero traffic are included in /traffic API responses