### PR TITLE
fix(app): invalid priority in output hook when setting redirect with nft

### DIFF
--- a/app/internal/firewall/firewall_linux.go
+++ b/app/internal/firewall/firewall_linux.go
@@ -97,7 +97,7 @@ func setupNFTablesRedirect(r commandRunner, listenAddr *net.UDPAddr, ports, redi
 		}
 		cleanup.add(func() { _ = nft("delete", "table", family, tableName) })
 		for _, chainArgs := range [][]string{
-			{"add", "chain", family, tableName, "prerouting", "{", "type", "nat", "hook", "prerouting", "priority", "dstnat;", "policy", "accept;", "}"},
+			{"add", "chain", family, tableName, "prerouting", "{", "type", "nat", "hook", "prerouting", "priority", "-100;", "policy", "accept;", "}"},
 			{"add", "chain", family, tableName, "output", "{", "type", "nat", "hook", "output", "priority", "-100;", "policy", "accept;", "}"},
 		} {
 			if err := nft(chainArgs...); err != nil {

--- a/app/internal/firewall/firewall_linux.go
+++ b/app/internal/firewall/firewall_linux.go
@@ -98,7 +98,7 @@ func setupNFTablesRedirect(r commandRunner, listenAddr *net.UDPAddr, ports, redi
 		cleanup.add(func() { _ = nft("delete", "table", family, tableName) })
 		for _, chainArgs := range [][]string{
 			{"add", "chain", family, tableName, "prerouting", "{", "type", "nat", "hook", "prerouting", "priority", "dstnat;", "policy", "accept;", "}"},
-			{"add", "chain", family, tableName, "output", "{", "type", "nat", "hook", "output", "priority", "dstnat;", "policy", "accept;", "}"},
+			{"add", "chain", family, tableName, "output", "{", "type", "nat", "hook", "output", "priority", "-100;", "policy", "accept;", "}"},
 		} {
 			if err := nft(chainArgs...); err != nil {
 				_ = cleanup.Close()


### PR DESCRIPTION
Server startup fails with nftables before v1.0.9, as it doesn't support dstnat mnemonic in the output hook. Work around this by using the raw number (-100) as recommended by Florian Westphal [1].

1. https://bugzilla.netfilter.org/show_bug.cgi?id=1694#c1