### PR TITLE
fix: struct literal unkeyed fields errors in utils.PortRange and utils.PortUnion

### DIFF
--- a/app/internal/firewall/firewall_linux_test.go
+++ b/app/internal/firewall/firewall_linux_test.go
@@ -35,7 +35,7 @@ func (r *fakeRunner) Run(name string, args ...string) error {
 func TestSetupUDPPortRedirectWithRunnerNFTables(t *testing.T) {
 	runner := &fakeRunner{paths: map[string]bool{"nft": true}}
 	addr := &net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 20000}
-	ports := eUtils.PortUnion{{20000, 20002}}
+	ports := eUtils.PortUnion{{Start: 20000, End: 20002}}
 
 	cleanup, err := setupUDPPortRedirectWithRunner(runner, addr, ports)
 	require.NoError(t, err)
@@ -54,7 +54,7 @@ func TestSetupUDPPortRedirectWithRunnerNFTables(t *testing.T) {
 func TestSetupUDPPortRedirectWithRunnerIPTablesFallback(t *testing.T) {
 	runner := &fakeRunner{paths: map[string]bool{"iptables": true}}
 	addr := &net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 20000}
-	ports := eUtils.PortUnion{{20000, 20000}, {20002, 20003}}
+	ports := eUtils.PortUnion{{Start: 20000, End: 20000}, {Start: 20002, End: 20003}}
 
 	cleanup, err := setupUDPPortRedirectWithRunner(runner, addr, ports)
 	require.NoError(t, err)
@@ -84,7 +84,7 @@ func TestSetupUDPPortRedirectWithRunnerRollback(t *testing.T) {
 		fail:  3,
 	}
 	addr := &net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 20000}
-	ports := eUtils.PortUnion{{20000, 20001}}
+	ports := eUtils.PortUnion{{Start: 20000, End: 20001}}
 
 	_, err := setupUDPPortRedirectWithRunner(runner, addr, ports)
 	require.Error(t, err)

--- a/extras/sniff/sniff_test.go
+++ b/extras/sniff/sniff_test.go
@@ -26,11 +26,11 @@ func TestSnifferCheck(t *testing.T) {
 	sniffer.RewriteDomain = true
 	assert.True(t, sniffer.Check(false, "example.com:443"))
 
-	sniffer.TCPPorts = []utils.PortRange{{80, 80}}
+	sniffer.TCPPorts = []utils.PortRange{{Start: 80, End: 80}}
 	assert.True(t, sniffer.Check(false, "google.com:80"))
 	assert.False(t, sniffer.Check(false, "google.com:443"))
 
-	sniffer.UDPPorts = []utils.PortRange{{443, 443}}
+	sniffer.UDPPorts = []utils.PortRange{{Start: 443, End: 443}}
 	assert.True(t, sniffer.Check(true, "google.com:443"))
 	assert.False(t, sniffer.Check(true, "google.com:80"))
 }

--- a/extras/utils/portunion.go
+++ b/extras/utils/portunion.go
@@ -21,7 +21,7 @@ type PortRange struct {
 func ParsePortUnion(s string) PortUnion {
 	if s == "all" || s == "*" {
 		// Wildcard special case
-		return PortUnion{PortRange{0, 65535}}
+		return PortUnion{PortRange{Start: 0, End: 65535}}
 	}
 	var result PortUnion
 	portStrs := strings.Split(s, ",")
@@ -43,14 +43,14 @@ func ParsePortUnion(s string) PortUnion {
 			if start > end {
 				start, end = end, start
 			}
-			result = append(result, PortRange{uint16(start), uint16(end)})
+			result = append(result, PortRange{Start: uint16(start), End: uint16(end)})
 		} else {
 			// Single port
 			port, err := strconv.ParseUint(portStr, 10, 16)
 			if err != nil {
 				return nil
 			}
-			result = append(result, PortRange{uint16(port), uint16(port)})
+			result = append(result, PortRange{Start: uint16(port), End: uint16(port)})
 		}
 	}
 	if result == nil {

--- a/extras/utils/portunion_test.go
+++ b/extras/utils/portunion_test.go
@@ -20,47 +20,47 @@ func TestParsePortUnion(t *testing.T) {
 		{
 			name: "all 1",
 			s:    "all",
-			want: PortUnion{{0, 65535}},
+			want: PortUnion{{Start: 0, End: 65535}},
 		},
 		{
 			name: "all 2",
 			s:    "*",
-			want: PortUnion{{0, 65535}},
+			want: PortUnion{{Start: 0, End: 65535}},
 		},
 		{
 			name: "single port",
 			s:    "1234",
-			want: PortUnion{{1234, 1234}},
+			want: PortUnion{{Start: 1234, End: 1234}},
 		},
 		{
 			name: "multiple ports (unsorted)",
 			s:    "5678,1234,9012",
-			want: PortUnion{{1234, 1234}, {5678, 5678}, {9012, 9012}},
+			want: PortUnion{{Start: 1234, End: 1234}, {Start: 5678, End: 5678}, {Start: 9012, End: 9012}},
 		},
 		{
 			name: "one range",
 			s:    "1234-1240",
-			want: PortUnion{{1234, 1240}},
+			want: PortUnion{{Start: 1234, End: 1240}},
 		},
 		{
 			name: "one range (reversed)",
 			s:    "1240-1234",
-			want: PortUnion{{1234, 1240}},
+			want: PortUnion{{Start: 1234, End: 1240}},
 		},
 		{
 			name: "multiple ports and ranges (reversed, unsorted, overlapping)",
 			s:    "5678,1200-1236,9100-9012,1234-1240",
-			want: PortUnion{{1200, 1240}, {5678, 5678}, {9012, 9100}},
+			want: PortUnion{{Start: 1200, End: 1240}, {Start: 5678, End: 5678}, {Start: 9012, End: 9100}},
 		},
 		{
 			name: "multiple ports and ranges with 65535 (reversed, unsorted, overlapping)",
 			s:    "5678,1200-1236,65531-65535,65532-65534,9100-9012,1234-1240",
-			want: PortUnion{{1200, 1240}, {5678, 5678}, {9012, 9100}, {65531, 65535}},
+			want: PortUnion{{Start: 1200, End: 1240}, {Start: 5678, End: 5678}, {Start: 9012, End: 9100}, {Start: 65531, End: 65535}},
 		},
 		{
 			name: "multiple ports and ranges with 65535 (reversed, unsorted, overlapping) 2",
 			s:    "5678,1200-1236,65532-65535,65531-65534,9100-9012,1234-1240",
-			want: PortUnion{{1200, 1240}, {5678, 5678}, {9012, 9100}, {65531, 65535}},
+			want: PortUnion{{Start: 1200, End: 1240}, {Start: 5678, End: 5678}, {Start: 9012, End: 9100}, {Start: 65531, End: 65535}},
 		},
 		{
 			name: "invalid 1",
@@ -110,32 +110,32 @@ func TestPortUnion_Ports(t *testing.T) {
 	}{
 		{
 			name: "single port",
-			pu:   PortUnion{{1234, 1234}},
+			pu:   PortUnion{{Start: 1234, End: 1234}},
 			want: []uint16{1234},
 		},
 		{
 			name: "multiple ports",
-			pu:   PortUnion{{1234, 1236}},
+			pu:   PortUnion{{Start: 1234, End: 1236}},
 			want: []uint16{1234, 1235, 1236},
 		},
 		{
 			name: "multiple ports and ranges",
-			pu:   PortUnion{{1234, 1236}, {5678, 5680}, {9000, 9002}},
+			pu:   PortUnion{{Start: 1234, End: 1236}, {Start: 5678, End: 5680}, {Start: 9000, End: 9002}},
 			want: []uint16{1234, 1235, 1236, 5678, 5679, 5680, 9000, 9001, 9002},
 		},
 		{
 			name: "single port 65535",
-			pu:   PortUnion{{65535, 65535}},
+			pu:   PortUnion{{Start: 65535, End: 65535}},
 			want: []uint16{65535},
 		},
 		{
 			name: "port range with 65535",
-			pu:   PortUnion{{65530, 65535}},
+			pu:   PortUnion{{Start: 65530, End: 65535}},
 			want: []uint16{65530, 65531, 65532, 65533, 65534, 65535},
 		},
 		{
 			name: "multiple ports and ranges with 65535",
-			pu:   PortUnion{{65530, 65535}, {1234, 1236}},
+			pu:   PortUnion{{Start: 65530, End: 65535}, {Start: 1234, End: 1236}},
 			want: []uint16{65530, 65531, 65532, 65533, 65534, 65535, 1234, 1235, 1236},
 		},
 	}


### PR DESCRIPTION
Fix struct literal unkeyed fields errors to improve code quality

- In `app/internal/firewall/firewall_linux_test.go`, update usages of `eUtils.PortUnion{{...}}` to `eUtils.PortUnion{{Start: ..., End: ...}}`.
- In `extras/sniff/sniff_test.go`, update usages of `[]utils.PortRange{{...}}` to `[]utils.PortRange{{Start: ..., End: ...}}`.
- In `extras/utils/portunion_test.go`, update usages of `PortUnion{{...}}` to `PortUnion{{Start: ..., End: ...}}`.
- In `extras/utils/portunion.go`, update `PortUnion{{0, 65535}}` to `PortUnion{{Start: 0, End: 65535}}`.
