### PR TITLE
fix(certloader): add SKI, AKI, KeyUsage extensions to test certs

### DIFF
--- a/app/internal/utils/certloader_test_gencert.py
+++ b/app/internal/utils/certloader_test_gencert.py
@@ -11,7 +11,7 @@ def create_key():
     return ec.generate_private_key(ec.SECP256R1())
 
 
-def create_certificate(cert_type, subject, issuer, private_key, public_key, dns_san=None):
+def create_certificate(cert_type, subject, issuer, private_key, public_key, dns_san=None, issuer_ski=None):
     serial_number = x509.random_serial_number()
     not_valid_before = datetime.datetime.now(datetime.UTC)
     not_valid_after = not_valid_before + datetime.timedelta(days=365)
@@ -33,17 +33,49 @@ def create_certificate(cert_type, subject, issuer, private_key, public_key, dns_
     builder = builder.serial_number(serial_number)
     builder = builder.not_valid_before(not_valid_before)
     builder = builder.not_valid_after(not_valid_after)
+
+    # Add Subject Key Identifier (required by OpenSSL 3.x)
+    builder = builder.add_extension(
+        x509.SubjectKeyIdentifier.from_public_key(public_key),
+        critical=False
+    )
+
+    # Add Authority Key Identifier if issuer SKI is provided
+    if issuer_ski is not None:
+        builder = builder.add_extension(
+            x509.AuthorityKeyIdentifier.from_issuer_subject_key_identifier(issuer_ski),
+            critical=False
+        )
+
     if cert_type == 'root':
         builder = builder.add_extension(
             x509.BasicConstraints(ca=True, path_length=None), critical=True
+        )
+        builder = builder.add_extension(
+            x509.KeyUsage(key_cert_sign=True, crl_sign=True, digital_signature=True,
+                          content_commitment=False, key_encipherment=False, data_encipherment=False,
+                          key_agreement=False, encipher_only=False, decipher_only=False),
+            critical=True
         )
     elif cert_type == 'intermediate':
         builder = builder.add_extension(
             x509.BasicConstraints(ca=True, path_length=0), critical=True
         )
+        builder = builder.add_extension(
+            x509.KeyUsage(key_cert_sign=True, crl_sign=True, digital_signature=True,
+                          content_commitment=False, key_encipherment=False, data_encipherment=False,
+                          key_agreement=False, encipher_only=False, decipher_only=False),
+            critical=True
+        )
     elif cert_type == 'leaf':
         builder = builder.add_extension(
             x509.BasicConstraints(ca=False, path_length=None), critical=True
+        )
+        builder = builder.add_extension(
+            x509.KeyUsage(key_cert_sign=False, crl_sign=False, digital_signature=True,
+                          content_commitment=False, key_encipherment=True, data_encipherment=False,
+                          key_agreement=False, encipher_only=False, decipher_only=False),
+            critical=True
         )
     else:
         raise ValueError(f'Invalid cert_type: {cert_type}')
@@ -100,6 +132,8 @@ def main():
             issuer=ca_subject,
             private_key=ca_key,
             public_key=ca_public_key)
+        ca_ski = ca_cert.extensions.get_extension_for_class(
+            x509.SubjectKeyIdentifier).value
 
         intermediate_key = create_key()
         intermediate_public_key = intermediate_key.public_key()
@@ -109,7 +143,10 @@ def main():
             subject=intermediate_subject,
             issuer=ca_subject,
             private_key=ca_key,
-            public_key=intermediate_public_key)
+            public_key=intermediate_public_key,
+            issuer_ski=ca_ski)
+        intermediate_ski = intermediate_cert.extensions.get_extension_for_class(
+            x509.SubjectKeyIdentifier).value
 
         leaf_subject = {"C": "ZZ", "O": "Leaf Certificate", "CN": "Leaf Certificate"}
         cert = create_certificate(
@@ -118,7 +155,8 @@ def main():
             issuer=intermediate_subject,
             private_key=intermediate_key,
             public_key=public_key,
-            dns_san=args.dnssan)
+            dns_san=args.dnssan,
+            issuer_ski=intermediate_ski)
 
         with open(args.ca, 'wb') as f:
             f.write(ca_cert.public_bytes(Encoding.PEM))


### PR DESCRIPTION
### Summary
OpenSSL 3.x enforces stricter X.509 certificate chain validation. The test certificate generator (certloader_test_gencert.py) was missing three required extensions, causing TestCertificateLoaderFullChain and TestCertificateLoaderReplaceCertificate to fail with errors like Missing Authority Key Identifier and Path length given without key usage keyCertSign.

### Log
```
$ python hyperbole.py test app
...
=== RUN   TestCertificateLoaderFullChain
2026/05/28 18:16:52 http: TLS handshake error from 127.0.0.1:37624: sni guard: x509: certificate is valid for example.com, not unmatched-sni.example.com
2026/05/28 18:16:52 Failed to run test TLS client: Error: [SSL: TLSV1_ALERT_INTERNAL_ERROR] tlsv1 alert internal error (_ssl.c:1032)
2026/05/28 18:16:52 http: TLS handshake error from 127.0.0.1:37636: sni guard: x509: cannot validate certificate for 127.82.39.147 because it doesn't contain any IP SANs
2026/05/28 18:16:52 Failed to run test TLS client: Error: [SSL: TLSV1_ALERT_INTERNAL_ERROR] tlsv1 alert internal error (_ssl.c:1032)
2026/05/28 18:16:52 http: TLS handshake error from 127.0.0.1:37650: local error: tls: bad record MAC
2026/05/28 18:16:52 Failed to run test TLS client: Error: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1032)
    certloader_test.go:54: 
                Error Trace:    /home/l27001/hysteria/app/internal/utils/certloader_test.go:54
                Error:          Received unexpected error:
                                exit status 1
                Test:           TestCertificateLoaderFullChain
--- FAIL: TestCertificateLoaderFullChain (0.23s)
=== RUN   TestCertificateLoaderNoSAN
--- PASS: TestCertificateLoaderNoSAN (0.11s)
=== RUN   TestCertificateLoaderReplaceCertificate
2026/05/28 18:16:52 http: TLS handshake error from 127.0.0.1:37672: local error: tls: bad record MAC
2026/05/28 18:16:52 Failed to run test TLS client: Error: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1032)
    certloader_test.go:94: 
                Error Trace:    /home/l27001/hysteria/app/internal/utils/certloader_test.go:94
                Error:          Received unexpected error:
                                exit status 1
                Test:           TestCertificateLoaderReplaceCertificate
2026/05/28 18:16:52 http: TLS handshake error from 127.0.0.1:37680: sni guard: x509: certificate is valid for example.com, not 2.example.com
2026/05/28 18:16:52 Failed to run test TLS client: Error: [SSL: TLSV1_ALERT_INTERNAL_ERROR] tlsv1 alert internal error (_ssl.c:1032)
2026/05/28 18:16:52 http: TLS handshake error from 127.0.0.1:37688: sni guard: x509: certificate is valid for 2.example.com, not example.com
2026/05/28 18:16:53 Failed to run test TLS client: Error: [SSL: TLSV1_ALERT_INTERNAL_ERROR] tlsv1 alert internal error (_ssl.c:1032)
2026/05/28 18:16:53 http: TLS handshake error from 127.0.0.1:37696: local error: tls: bad record MAC
2026/05/28 18:16:53 Failed to run test TLS client: Error: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1032)
    certloader_test.go:100: 
                Error Trace:    /home/l27001/hysteria/app/internal/utils/certloader_test.go:100
                Error:          Received unexpected error:
                                exit status 1
                Test:           TestCertificateLoaderReplaceCertificate
--- FAIL: TestCertificateLoaderReplaceCertificate (0.29s)
FAIL
FAIL    github.com/apernet/hysteria/app/v2/internal/utils       0.634s
?       github.com/apernet/hysteria/app/v2/internal/utils_test  [no test files]
FAIL
Failed to test ./app
```

### Changes
Added the following X.509 extensions to all generated test certificates:
- Subject Key Identifier (SKI) — added to all certificates via SubjectKeyIdentifier.from_public_key()
- Authority Key Identifier (AKI) — intermediate cert references root's SKI, leaf cert references intermediate's SKI
- Key Usage — keyCertSign + crlSign + digitalSignature for root and intermediate CAs; digitalSignature + keyEncipherment for leaf certs

### Testing
All certloader tests now pass on systems with OpenSSL 3.x:
```
$ python3 hyperbole.py test app
=== RUN   TestCertificateLoaderFullChain
2026/05/28 18:18:06 http: TLS handshake error from 127.0.0.1:57004: sni guard: x509: certificate is valid for example.com, not unmatched-sni.example.com
2026/05/28 18:18:06 Failed to run test TLS client: Error: [SSL: TLSV1_ALERT_INTERNAL_ERROR] tlsv1 alert internal error (_ssl.c:1032)
2026/05/28 18:18:06 http: TLS handshake error from 127.0.0.1:57012: sni guard: x509: cannot validate certificate for 127.82.39.147 because it doesn't contain any IP SANs
2026/05/28 18:18:06 Failed to run test TLS client: Error: [SSL: TLSV1_ALERT_INTERNAL_ERROR] tlsv1 alert internal error (_ssl.c:1032)
--- PASS: TestCertificateLoaderFullChain (0.22s)
=== RUN   TestCertificateLoaderNoSAN
--- PASS: TestCertificateLoaderNoSAN (0.12s)
=== RUN   TestCertificateLoaderReplaceCertificate
2026/05/28 18:18:06 http: TLS handshake error from 127.0.0.1:57048: sni guard: x509: certificate is valid for example.com, not 2.example.com
2026/05/28 18:18:06 Failed to run test TLS client: Error: [SSL: TLSV1_ALERT_INTERNAL_ERROR] tlsv1 alert internal error (_ssl.c:1032)
2026/05/28 18:18:06 http: TLS handshake error from 127.0.0.1:57056: sni guard: x509: certificate is valid for 2.example.com, not example.com
2026/05/28 18:18:06 Failed to run test TLS client: Error: [SSL: TLSV1_ALERT_INTERNAL_ERROR] tlsv1 alert internal error (_ssl.c:1032)
--- PASS: TestCertificateLoaderReplaceCertificate (0.30s)
PASS
ok      github.com/apernet/hysteria/app/v2/internal/utils       0.643s
?       github.com/apernet/hysteria/app/v2/internal/utils_test  [no test files]
```