### PR TITLE
feat(realm): add ipMode option to restrict connections to v4 or v6

### DIFF
--- a/app/cmd/client.go
+++ b/app/cmd/client.go
@@ -96,7 +96,21 @@ type clientConfigRealm struct {
 	STUNTimeout  time.Duration          `mapstructure:"stunTimeout"`
 	PunchTimeout time.Duration          `mapstructure:"punchTimeout"`
 	Insecure     bool                   `mapstructure:"insecure"`
+	IPMode       string                 `mapstructure:"ipMode"`
 	PortMapping  realmPortMappingConfig `mapstructure:"portMapping"`
+}
+
+func realmIPMode(mode string) (realm.AddrFamily, string, error) {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "", "dual":
+		return realm.AddrFamilyAny, "udp", nil
+	case "v4":
+		return realm.AddrFamilyIPv4, "udp4", nil
+	case "v6":
+		return realm.AddrFamilyIPv6, "udp6", nil
+	default:
+		return realm.AddrFamilyAny, "", fmt.Errorf("invalid ipMode %q (expected v4, v6, or dual)", mode)
+	}
 }
 
 type clientConfigTransportUDP struct {
@@ -615,7 +629,10 @@ func (c *clientConfig) realmConfig(addr *realm.Addr) (*client.Config, error) {
 	if c.TLS.SNI == "" {
 		hyConfig.TLSConfig.ServerName = addr.Host
 	}
-
+	family, network, err := realmIPMode(c.Realm.IPMode)
+	if err != nil {
+		return nil, configError{Field: "realm.ipMode", Err: err}
+	}
 	so, err := c.socketOptions()
 	if err != nil {
 		return nil, err
@@ -624,7 +641,7 @@ func (c *clientConfig) realmConfig(addr *realm.Addr) (*client.Config, error) {
 	if addr.LocalPort != 0 {
 		listenAddr = &net.UDPAddr{Port: addr.LocalPort}
 	}
-	baseConn, err := so.ListenUDPAddr(listenAddr)
+	baseConn, err := so.ListenUDPAddrNetwork(network, listenAddr)
 	if err != nil {
 		return nil, configError{Field: "realm", Err: err}
 	}
@@ -663,6 +680,7 @@ func (c *clientConfig) realmConfig(addr *realm.Addr) (*client.Config, error) {
 	localAddrs, err := realm.Discover(ctx, baseConn, realm.STUNConfig{
 		Servers: stunServers,
 		Timeout: c.Realm.STUNTimeout,
+		Family:  family,
 	})
 	if err != nil {
 		return nil, configError{Field: "realm.stun", Err: err}
@@ -711,6 +729,7 @@ func (c *clientConfig) realmConfig(addr *realm.Addr) (*client.Config, error) {
 	punchStart := time.Now()
 	result, err := realm.Punch(ctx, baseConn, localAddrs, peerAddrs, connectResp.PunchMetadata, realm.PunchConfig{
 		Timeout: c.Realm.PunchTimeout,
+		Family:  family,
 	})
 	if err != nil {
 		return nil, configError{Field: "realm.punch", Err: err}

--- a/app/cmd/server.go
+++ b/app/cmd/server.go
@@ -91,6 +91,7 @@ type serverConfigRealm struct {
 	PunchTimeout      time.Duration          `mapstructure:"punchTimeout"`
 	HeartbeatInterval time.Duration          `mapstructure:"heartbeatInterval"`
 	Insecure          bool                   `mapstructure:"insecure"`
+	IPMode            string                 `mapstructure:"ipMode"`
 	PortMapping       realmPortMappingConfig `mapstructure:"portMapping"`
 }
 
@@ -349,11 +350,15 @@ func (c *serverConfig) fillRealmConn(hyConfig *server.Config, addr *realm.Addr) 
 		zap.String("realm", addr.RealmID),
 		zap.String("realmServer", addr.HostPort),
 		zap.String("scheme", addr.RendezvousScheme))
+	family, network, err := realmIPMode(c.Realm.IPMode)
+	if err != nil {
+		return configError{Field: "realm.ipMode", Err: err}
+	}
 	listenAddr := &net.UDPAddr{}
 	if addr.LocalPort != 0 {
 		listenAddr.Port = addr.LocalPort
 	}
-	conn, err := correctnet.ListenUDP("udp", listenAddr)
+	conn, err := correctnet.ListenUDP(network, listenAddr)
 	if err != nil {
 		return configError{Field: "listen", Err: err}
 	}
@@ -373,7 +378,7 @@ func (c *serverConfig) fillRealmConn(hyConfig *server.Config, addr *realm.Addr) 
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	runtime, err := c.startRealmServerRuntime(ctx, cancel, addr, punchConn)
+	runtime, err := c.startRealmServerRuntime(ctx, cancel, addr, punchConn, family)
 	if err != nil {
 		cancel()
 		_ = packetConn.Close()
@@ -428,7 +433,7 @@ func resolveServerListenAddr(listenAddr string) (*net.UDPAddr, eUtils.PortUnion,
 	return uAddr, portUnion, err
 }
 
-func (c *serverConfig) startRealmServerRuntime(ctx context.Context, cancel context.CancelFunc, addr *realm.Addr, punchConn *realm.PunchPacketConn) (*realmServerRuntime, error) {
+func (c *serverConfig) startRealmServerRuntime(ctx context.Context, cancel context.CancelFunc, addr *realm.Addr, punchConn *realm.PunchPacketConn, family realm.AddrFamily) (*realmServerRuntime, error) {
 	stunServers := c.realmSTUNServers(addr)
 	rClient, err := realm.NewClientFromAddr(addr, c.realmHTTPClient())
 	if err != nil {
@@ -446,6 +451,7 @@ func (c *serverConfig) startRealmServerRuntime(ctx context.Context, cancel conte
 		stunServers: stunServers,
 		puncher:     puncher,
 		config:      c.Realm,
+		family:      family,
 	}
 	// Gateway port mapping (UPnP/NAT-PMP) runs before STUN.
 	// With the pinhole in place, in a double-NAT setup,
@@ -509,6 +515,7 @@ type realmServerRuntime struct {
 	stunServers []string
 	puncher     *realm.ServerPuncher
 	config      serverConfigRealm
+	family      realm.AddrFamily
 	mapper      *realm.PortMapper // nil if port mapping is disabled or failed
 
 	mu      sync.Mutex
@@ -782,6 +789,7 @@ func (r *realmServerRuntime) respond(ctx context.Context, ev *realm.PunchEvent) 
 	start := time.Now()
 	result, err := r.puncher.Respond(ctx, ev.Nonce, freshAddrs, peerAddrs, ev.PunchMetadata, realm.PunchConfig{
 		Timeout: r.config.PunchTimeout,
+		Family:  r.family,
 	})
 	if err != nil {
 		logger.Warn("realm punch failed", zap.String("realm", r.realmID), zap.String("attempt", attempt), zap.Error(err))
@@ -843,6 +851,7 @@ func (r *realmServerRuntime) refreshAddrsWith(ctx context.Context, discover func
 	addrs, err := discover(ctx, realm.STUNConfig{
 		Servers: r.stunServers,
 		Timeout: r.config.STUNTimeout,
+		Family:  r.family,
 	})
 	if err != nil {
 		return nil, false, err

--- a/app/internal/sockopts/sockopts.go
+++ b/app/internal/sockopts/sockopts.go
@@ -46,7 +46,12 @@ func (o *SocketOptions) ListenUDP() (net.PacketConn, error) {
 // ListenUDPAddr is like ListenUDP but binds to a specific local UDP address.
 // Pass nil to use an ephemeral port (same as ListenUDP).
 func (o *SocketOptions) ListenUDPAddr(addr *net.UDPAddr) (net.PacketConn, error) {
-	uconn, err := net.ListenUDP("udp", addr)
+	return o.ListenUDPAddrNetwork("udp", addr)
+}
+
+// ListenUDPAddrNetwork is like ListenUDPAddr but binds to a specific network type.
+func (o *SocketOptions) ListenUDPAddrNetwork(network string, addr *net.UDPAddr) (net.PacketConn, error) {
+	uconn, err := net.ListenUDP(network, addr)
 	if err != nil {
 		return nil, err
 	}

--- a/extras/realm/punch_engine.go
+++ b/extras/realm/punch_engine.go
@@ -28,6 +28,7 @@ var (
 type PunchConfig struct {
 	Timeout  time.Duration
 	Interval time.Duration
+	Family   AddrFamily
 }
 
 type PunchResult struct {
@@ -44,7 +45,7 @@ func Punch(ctx context.Context, conn net.PacketConn, localAddrs, peerAddrs []net
 	if _, _, err := decodePunchMetadata(meta); err != nil {
 		return PunchResult{}, err
 	}
-	candidates := candidatePunchAddrs(localAddrs, peerAddrs, localAddrFamily(conn.LocalAddr()))
+	candidates := candidatePunchAddrs(localAddrs, peerAddrs, effectiveFamily(config.Family, conn.LocalAddr()))
 	if len(candidates) == 0 {
 		return PunchResult{}, fmt.Errorf("%w: no compatible peer addresses", ErrInvalidPunchConfig)
 	}
@@ -126,8 +127,8 @@ func sendPunchPacket(conn net.PacketConn, addr netip.AddrPort, meta PunchMetadat
 	_, _ = conn.WriteTo(packet, udpAddrFromAddrPort(addr))
 }
 
-func candidatePunchAddrs(localAddrs, peerAddrs []netip.AddrPort, connFamily addrFamily) []netip.AddrPort {
-	allowedFamilies := punchFamilies(localAddrs, connFamily)
+func candidatePunchAddrs(localAddrs, peerAddrs []netip.AddrPort, family AddrFamily) []netip.AddrPort {
+	allowedFamilies := punchFamilies(localAddrs, family)
 	seen := make(map[netip.AddrPort]struct{})
 	var candidates []netip.AddrPort
 	for _, addr := range peerAddrs {
@@ -216,7 +217,15 @@ type punchFamilySet struct {
 	v6 bool
 }
 
-func punchFamilies(localAddrs []netip.AddrPort, connFamily addrFamily) punchFamilySet {
+func punchFamilies(localAddrs []netip.AddrPort, family AddrFamily) punchFamilySet {
+	switch family {
+	case AddrFamilyIPv4:
+		return punchFamilySet{v4: true}
+	case AddrFamilyIPv6:
+		return punchFamilySet{v6: true}
+	}
+	// Otherwise derive the families from the locally gathered addresses,
+	// falling back to both when none are known.
 	var families punchFamilySet
 	for _, addr := range localAddrs {
 		if !addr.IsValid() {
@@ -228,15 +237,7 @@ func punchFamilies(localAddrs []netip.AddrPort, connFamily addrFamily) punchFami
 			families.v6 = true
 		}
 	}
-	if families.v4 || families.v6 {
-		return families
-	}
-	switch connFamily {
-	case addrFamilyIPv4:
-		families.v4 = true
-	case addrFamilyIPv6:
-		families.v6 = true
-	default:
+	if !families.v4 && !families.v6 {
 		families.v4 = true
 		families.v6 = true
 	}

--- a/extras/realm/punch_engine_test.go
+++ b/extras/realm/punch_engine_test.go
@@ -103,8 +103,25 @@ func TestCandidatePunchAddrsFiltersByFamily(t *testing.T) {
 		netip.MustParseAddrPort("198.51.100.20:4433"),
 	}
 
-	candidates := candidatePunchAddrs(local, peer, addrFamilyAny)
+	candidates := candidatePunchAddrs(local, peer, AddrFamilyAny)
 	assert.Equal(t, []netip.AddrPort{netip.MustParseAddrPort("198.51.100.20:4433")}, candidates)
+}
+
+func TestCandidatePunchAddrsExplicitFamilyIsAuthoritative(t *testing.T) {
+	local := []netip.AddrPort{
+		netip.MustParseAddrPort("192.0.2.10:1234"),
+		netip.MustParseAddrPort("[2001:db8::10]:1234"),
+	}
+	peer := []netip.AddrPort{
+		netip.MustParseAddrPort("198.51.100.20:4433"),
+		netip.MustParseAddrPort("[2001:db8::1]:4433"),
+	}
+
+	v4 := candidatePunchAddrs(local, peer, AddrFamilyIPv4)
+	assert.Equal(t, []netip.AddrPort{netip.MustParseAddrPort("198.51.100.20:4433")}, v4)
+
+	v6 := candidatePunchAddrs(local, peer, AddrFamilyIPv6)
+	assert.Equal(t, []netip.AddrPort{netip.MustParseAddrPort("[2001:db8::1]:4433")}, v6)
 }
 
 func TestCandidatePunchAddrsExpandsPredictableIPv4Ports(t *testing.T) {
@@ -114,7 +131,7 @@ func TestCandidatePunchAddrsExpandsPredictableIPv4Ports(t *testing.T) {
 		netip.MustParseAddrPort("198.51.100.20:40003"),
 	}
 
-	candidates := candidatePunchAddrs(local, peer, addrFamilyAny)
+	candidates := candidatePunchAddrs(local, peer, AddrFamilyAny)
 	assert.Equal(t, []netip.AddrPort{
 		netip.MustParseAddrPort("198.51.100.20:40000"),
 		netip.MustParseAddrPort("198.51.100.20:40001"),
@@ -134,7 +151,7 @@ func TestCandidatePunchAddrsDoesNotExpandLargePortGaps(t *testing.T) {
 		netip.MustParseAddrPort("198.51.100.20:40010"),
 	}
 
-	candidates := candidatePunchAddrs(local, peer, addrFamilyAny)
+	candidates := candidatePunchAddrs(local, peer, AddrFamilyAny)
 	assert.Equal(t, peer, candidates)
 }
 
@@ -145,7 +162,7 @@ func TestCandidatePunchAddrsDoesNotExpandIPv6(t *testing.T) {
 		netip.MustParseAddrPort("[2001:db8::20]:40001"),
 	}
 
-	candidates := candidatePunchAddrs(local, peer, addrFamilyAny)
+	candidates := candidatePunchAddrs(local, peer, AddrFamilyAny)
 	assert.Equal(t, peer, candidates)
 }
 
@@ -156,7 +173,7 @@ func TestCandidatePunchAddrsExpansionHandlesPortBounds(t *testing.T) {
 		netip.MustParseAddrPort("198.51.100.20:65535"),
 	}
 
-	candidates := candidatePunchAddrs(local, peer, addrFamilyAny)
+	candidates := candidatePunchAddrs(local, peer, AddrFamilyAny)
 	assert.Equal(t, []netip.AddrPort{
 		netip.MustParseAddrPort("198.51.100.20:65534"),
 		netip.MustParseAddrPort("198.51.100.20:65535"),

--- a/extras/realm/server_punch.go
+++ b/extras/realm/server_punch.go
@@ -46,7 +46,7 @@ func (p *ServerPuncher) Respond(ctx context.Context, attemptID string, localAddr
 	if _, _, err := decodePunchMetadata(meta); err != nil {
 		return PunchResult{}, err
 	}
-	candidates := candidatePunchAddrs(localAddrs, peerAddrs, localAddrFamily(p.conn.LocalAddr()))
+	candidates := candidatePunchAddrs(localAddrs, peerAddrs, effectiveFamily(config.Family, p.conn.LocalAddr()))
 	if len(candidates) == 0 {
 		return PunchResult{}, fmt.Errorf("%w: no compatible peer addresses", ErrInvalidPunchConfig)
 	}

--- a/extras/realm/stun.go
+++ b/extras/realm/stun.go
@@ -29,6 +29,7 @@ type STUNConfig struct {
 	Servers  []string
 	Timeout  time.Duration
 	Resolver STUNResolver
+	Family   AddrFamily
 }
 
 // Discover queries the configured STUN servers using conn and returns the
@@ -55,7 +56,7 @@ func Discover(ctx context.Context, conn net.PacketConn, config STUNConfig) ([]ne
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	stunAddrs, err := resolveSTUNServers(ctx, resolver, config.Servers, localAddrFamily(conn.LocalAddr()))
+	stunAddrs, err := resolveSTUNServers(ctx, resolver, config.Servers, effectiveFamily(config.Family, conn.LocalAddr()))
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +115,7 @@ func DiscoverWithDemux(ctx context.Context, conn *PunchPacketConn, config STUNCo
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	stunAddrs, err := resolveSTUNServers(ctx, resolver, config.Servers, localAddrFamily(conn.LocalAddr()))
+	stunAddrs, err := resolveSTUNServers(ctx, resolver, config.Servers, effectiveFamily(config.Family, conn.LocalAddr()))
 	if err != nil {
 		return nil, err
 	}
@@ -139,7 +140,7 @@ func DiscoverWithDemux(ctx context.Context, conn *PunchPacketConn, config STUNCo
 	return finishSTUNResults(results, nil)
 }
 
-func resolveSTUNServers(ctx context.Context, resolver STUNResolver, servers []string, family addrFamily) ([]*net.UDPAddr, error) {
+func resolveSTUNServers(ctx context.Context, resolver STUNResolver, servers []string, family AddrFamily) ([]*net.UDPAddr, error) {
 	var out []*net.UDPAddr
 	seen := make(map[string]struct{})
 	for _, server := range servers {
@@ -278,31 +279,40 @@ func netIPPortToAddrPort(ip net.IP, port int) (netip.AddrPort, error) {
 	return netip.AddrPortFrom(netip.AddrFrom16(addr), uint16(port)), nil
 }
 
-type addrFamily uint8
+type AddrFamily uint8
 
 const (
-	addrFamilyAny addrFamily = iota
-	addrFamilyIPv4
-	addrFamilyIPv6
+	AddrFamilyAny AddrFamily = iota
+	AddrFamilyIPv4
+	AddrFamilyIPv6
 )
 
-func localAddrFamily(addr net.Addr) addrFamily {
-	udpAddr, ok := addr.(*net.UDPAddr)
-	if !ok || udpAddr.IP == nil || udpAddr.IP.IsUnspecified() {
-		return addrFamilyAny
+// effectiveFamily resolves the family to use: an explicit restriction takes
+// precedence, otherwise it is inferred from the socket's local address.
+func effectiveFamily(family AddrFamily, local net.Addr) AddrFamily {
+	if family != AddrFamilyAny {
+		return family
 	}
-	if udpAddr.IP.To4() != nil {
-		return addrFamilyIPv4
-	}
-	return addrFamilyIPv6
+	return localAddrFamily(local)
 }
 
-func (f addrFamily) allows(ip net.IP) bool {
+func localAddrFamily(addr net.Addr) AddrFamily {
+	udpAddr, ok := addr.(*net.UDPAddr)
+	if !ok || udpAddr.IP == nil || udpAddr.IP.IsUnspecified() {
+		return AddrFamilyAny
+	}
+	if udpAddr.IP.To4() != nil {
+		return AddrFamilyIPv4
+	}
+	return AddrFamilyIPv6
+}
+
+func (f AddrFamily) allows(ip net.IP) bool {
 	is4 := ip.To4() != nil
 	switch f {
-	case addrFamilyIPv4:
+	case AddrFamilyIPv4:
 		return is4
-	case addrFamilyIPv6:
+	case AddrFamilyIPv6:
 		return !is4
 	default:
 		return true

--- a/extras/realm/stun_test.go
+++ b/extras/realm/stun_test.go
@@ -98,7 +98,7 @@ func TestResolveSTUNServersUsesAllResolvedAddresses(t *testing.T) {
 		},
 	}
 
-	addrs, err := resolveSTUNServers(context.Background(), resolver, []string{"stun.example.com:19302"}, addrFamilyAny)
+	addrs, err := resolveSTUNServers(context.Background(), resolver, []string{"stun.example.com:19302"}, AddrFamilyAny)
 	require.NoError(t, err)
 	require.Len(t, addrs, 2)
 	assert.ElementsMatch(t, []string{"192.0.2.1:19302", "[2001:db8::1]:19302"}, udpAddrStrings(addrs))
@@ -112,11 +112,11 @@ func TestResolveSTUNServersFiltersByLocalFamily(t *testing.T) {
 		},
 	}
 
-	addrs, err := resolveSTUNServers(context.Background(), resolver, []string{"stun.example.com"}, addrFamilyIPv4)
+	addrs, err := resolveSTUNServers(context.Background(), resolver, []string{"stun.example.com"}, AddrFamilyIPv4)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"192.0.2.1:3478"}, udpAddrStrings(addrs))
 
-	addrs, err = resolveSTUNServers(context.Background(), resolver, []string{"stun.example.com"}, addrFamilyIPv6)
+	addrs, err = resolveSTUNServers(context.Background(), resolver, []string{"stun.example.com"}, AddrFamilyIPv6)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"[2001:db8::1]:3478"}, udpAddrStrings(addrs))
 }


### PR DESCRIPTION
Adds a new realm "ipMode" config option (v4 | v6 | dual, default dual) on both client and server that restricts realm connections to a single IP family end-to-end: the UDP socket is bound to udp4/udp6, STUN only gathers addresses of that family, and hole punching only tries peer candidates of that family.