### PR TITLE
fix(proxymux): fix data race on httpListener/socksListener in mainLoop

### DIFF
--- a/app/internal/proxymux/mux.go
+++ b/app/internal/proxymux/mux.go
@@ -75,12 +75,14 @@ func (l *muxListener) mainLoop() {
 
 	for {
 		var socksCloseChan, httpCloseChan chan struct{}
+		l.lock.Lock()
 		if l.httpListener != nil {
 			httpCloseChan = l.httpListener.closeChan
 		}
 		if l.socksListener != nil {
 			socksCloseChan = l.socksListener.closeChan
 		}
+		l.lock.Unlock()
 		select {
 		case <-l.closeChan:
 			return


### PR DESCRIPTION
mainLoop() reads l.httpListener and l.socksListener without holding l.lock, while ListenHTTP() and ListenSOCKS() write to these fields under the lock. This is a classic data race detectable with go test -race.

The fix acquires l.lock around the reads in the main loop iteration, copying the close channels while holding the lock, then releases it before entering the select statement. This is consistent with how all other reads of these fields (dispatch, checkIdle, defer cleanup) are already protected.