### PR TITLE
fix(client): fix auth + character corrupted in URI parsing

### DIFF
--- a/app/cmd/client.go
+++ b/app/cmd/client.go
@@ -539,11 +539,13 @@ func (c *clientConfig) parseURI() bool {
 		return false
 	}
 	if u.User != nil {
-		auth, err := url.QueryUnescape(u.User.String())
-		if err != nil {
-			return false
+		username := u.User.Username()
+		password, hasPassword := u.User.Password()
+		if hasPassword {
+			c.Auth = username + ":" + password
+		} else {
+			c.Auth = username
 		}
-		c.Auth = auth
 	}
 	c.Server = u.Host
 	q := u.Query()


### PR DESCRIPTION
parseURI() used url.QueryUnescape(u.User.String()) to extract auth credentials from the URI. QueryUnescape treats '+' as a space (HTML form encoding), but '+' is a valid character in URI userinfo per RFC 3986 and is left unencoded by url.UserPassword(). This means a password like 'pass+word' would be silently corrupted to 'pass word'.

Replace the QueryUnescape approach with u.User.Username() and u.User.Password(), which correctly return the decoded userinfo values without the '+' → space substitution. This also eliminates the unnecessary error handling branch for the unescape failure case.