### PR TITLE
fix: remove the requirement for the optional mimic kernel module

### DIFF
--- a/app/internal/mimic/mimic.go
+++ b/app/internal/mimic/mimic.go
@@ -4,7 +4,8 @@
 // Mimic disguises UDP as TCP by rewriting packets in the kernel, transparently
 // to the socket. We derive its filter from the address Hysteria already knows,
 // so users don't have to configure it separately. Installing it is still up to
-// them: its eBPF programs need its kernel module loaded.
+// them; whether its optional kernel module is loaded is Mimic's business, and
+// it says so itself when it needs it.
 package mimic
 
 type Config struct {

--- a/app/internal/mimic/mimic_linux.go
+++ b/app/internal/mimic/mimic_linux.go
@@ -22,7 +22,6 @@ import (
 
 const (
 	runtimeDir     = "/run/mimic"
-	modulePath     = "/sys/module/mimic"
 	readyTimeout   = 10 * time.Second
 	readyPollEvery = 100 * time.Millisecond
 )
@@ -48,9 +47,6 @@ func Start(cfg Config, role Role, addr *net.UDPAddr, logger *zap.Logger, onExit 
 	}
 	bin, err := resolveBinary(cfg.Path)
 	if err != nil {
-		return nil, err
-	}
-	if err := checkModule(); err != nil {
 		return nil, err
 	}
 	iface, err := resolveInterface(cfg.Interface, role, addr)
@@ -170,14 +166,6 @@ func resolveBinary(path string) (string, error) {
 		return "", errors.New("mimic not found in PATH; install it from https://github.com/hack3ric/mimic")
 	}
 	return bin, nil
-}
-
-func checkModule() error {
-	if _, err := os.Stat(modulePath); err != nil {
-		return errors.New("mimic kernel module is not loaded; run 'modprobe mimic' " +
-			"(the module is built by the mimic-dkms package and needs kernel headers installed)")
-	}
-	return nil
 }
 
 // runningOn reports whether a Mimic already owns the interface. Mimic only


### PR DESCRIPTION
Mimic keeps its kernel module optional. The module carries a checksum hack for TX checksum offload. Mimic needs that hack when the NIC driver uses `csum_offset` and the UDP socket lives in the kernel.

Hysteria sends from a userspace socket. Drivers such as Realtek and Mediatek skip `csum_offset`, and an operator can switch the offload off. These cases make the hack optional. Mimic documents them in [`docs/checksum-hacks.md`](https://github.com/hack3ric/mimic/blob/master/docs/checksum-hacks.md). The `kprobe` build, which OpenWrt uses, makes the module optional for every case.

`mimic.Start` read `/sys/module/mimic` first and stopped Hysteria at startup. This commit removes that check. Mimic decides whether it needs the module.
